### PR TITLE
Introduce --move-warc-to for upload pipelines

### DIFF
--- a/doc/terse_options.rst
+++ b/doc/terse_options.rst
@@ -35,6 +35,7 @@ Brief Option Overview
                      [--random-file FILE] [--edg-file FILE]
                      [--warc-file FILENAME] [--warc-append]
                      [--warc-header STRING] [--warc-max-size NUMBER]
+                     [--move-warc-to DIR]
                      [--warc-cdx] [--warc-dedup FILE] [--no-warc-compression]
                      [--no-warc-digests] [--no-warc-keep-log]
                      [--warc-tempdir DIRECTORY] [-r] [-l NUMBER]
@@ -196,6 +197,8 @@ Brief Option Overview
     --warc-header STRING  include STRING in WARC file metadata
     --warc-max-size NUMBER
                           write sequential WARC files sized about NUMBER bytes
+    --move-warc-to DIR    once a sequential WARC file has reached its max size,
+                          move it to DIR
     --warc-cdx            write CDX file along with the WARC file
     --warc-dedup FILE     write revisit records using digests in FILE
     --no-warc-compression

--- a/wpull/app.py
+++ b/wpull/app.py
@@ -548,6 +548,7 @@ class Builder(object):
                         digests=args.warc_digests,
                         cdx=args.warc_cdx,
                         max_size=args.warc_max_size,
+                        move_to=args.move_warc_to,
                         url_table=self._factory['URLTable'] if args.warc_dedup
                             else None,
                         software_string=software_string,

--- a/wpull/options.py
+++ b/wpull/options.py
@@ -891,6 +891,12 @@ class AppArgumentParser(argparse.ArgumentParser):
             help=_('write sequential WARC files sized about NUMBER bytes')
         )
         group.add_argument(
+            '--move-warc-to',
+            metavar='DIRECTORY',
+            default=None,
+            help=_('once a sequential WARC file has reached its max size, move it to DIRECTORY')
+        )
+        group.add_argument(
             '--warc-cdx',
             action='store_true',
             help=_('write CDX file along with the WARC file')

--- a/wpull/recorder.py
+++ b/wpull/recorder.py
@@ -11,6 +11,7 @@ import logging
 import os.path
 import re
 import sys
+import shutil
 from tempfile import NamedTemporaryFile
 import tempfile
 import time
@@ -140,6 +141,7 @@ WARCRecorderParams = namedlist.namedtuple(
         ('digests', True),
         ('cdx', None),
         ('max_size', None),
+        ('move_to', None),
         ('url_table', None),
         ('software_string', None)
     ]
@@ -157,6 +159,8 @@ Args:
     cdx (bool): If True, a CDX file will be written.
     max_size (int): If provided, output files are named like
         ``name-00000.ext`` and the log file will be in ``name-meta.ext``.
+    move_to (str): If provided, completed sequential WARCs will be moved
+        to the given directory
     url_table (:class:`.database.URLTable`): If given, then ``revist``
         records will be written.
     software_string (str): The value for the ``software`` field in the
@@ -283,6 +287,15 @@ class WARCRecorder(BaseRecorder):
         if self._params.max_size is not None \
         and os.path.getsize(self._warc_filename) > self._params.max_size:
             self._sequence_num += 1
+
+            if self._params.move_to is not None:
+                if os.path.isdir(self._params.move_to):
+                    _logger.debug('Moved %s to %s.' % (self._warc_filename,
+                        self._params.move_to))
+                    shutil.move(self._warc_filename, self._params.move_to)
+                else:
+                    _logger.error('%s is not a directory; not moving %s.' %
+                            (self._params.move_to, self._warc_filename))
 
             _logger.debug('Starting new warc file due to max size.')
             self._start_new_warc_file()


### PR DESCRIPTION
This PR introduces `--move-warc-to DIR`, which is intended to make wpull fit better in upload pipelines like https://github.com/ArchiveTeam/archiveteam-megawarc-factory.  

Origin: @Asparagirl has a project with constraints that makes this capability useful.  Check out http://badcheese.com/~steve/atlogs/?chan=archiveteam&day=2014-05-30 around the 04:30:00 mark for more information.

The problem: it is currently not easy to determine when wpull has completed a WARC file in a series of WARCs, and we cannot safely upload a sequential WARC while it is being written.  The megawarc factory code addresses this problem by requiring atomic mv and watching a directory for new files.

`--move-warc-to DIR` allows completed WARCs to be moved off to an upload staging directory; from that point, scripts like the megawarc uploader can be used as-is.

This PR is not yet production ready; consider this more of a reality check request, i.e. "am I even doing this right?"  Here are the problems I know of:
- No tests.  I'm still coming to grips with the test suite.
- I'm not sure how this interacts with CDXes or the meta-WARC.  (As far as I can tell, it ignores them.)  The right thing to do here may be to move the CDX and meta-WARC on job completion to the given directory.
- This option could in theory be applied to any WARC recording situation.  This patch does not implement it that way, however.
