### PR TITLE
wpull 2.0.3 (was: Fix two crashes on asyncio SSL calls and --warc-max-size on HTTP(S) grabs)

### DIFF
--- a/wpull/application/app.py
+++ b/wpull/application/app.py
@@ -130,6 +130,11 @@ class Application(HookableMixin):
             int: The exit status.
         '''
         exit_status = asyncio.get_event_loop().run_until_complete(self.run())
+
+        # The following loop close procedure should avoid deadlock while
+        # allowing all callbacks to process before close()
+        asyncio.get_event_loop().stop()
+        asyncio.get_event_loop().run_forever()
         asyncio.get_event_loop().close()
         return exit_status
 

--- a/wpull/application/tasks/database.py
+++ b/wpull/application/tasks/database.py
@@ -76,17 +76,21 @@ class InputURLTask(ItemTask[AppSession]):
             if base_url:
                 url_string = wpull.url.urljoin(base_url, url_string)
 
-            url_info = wpull.url.URLInfo.parse(
-                url_string, default_scheme=default_scheme)
+            try:
+                url_info = wpull.url.URLInfo.parse(
+                    url_string, default_scheme=default_scheme)
 
-            _logger.debug(__('Parsed URL {0}', url_info))
+                _logger.debug(__('Parsed URL {0}', url_info))
 
-            if url_rewriter:
-                # TODO: this logic should be a hook
-                url_info = url_rewriter.rewrite(url_info)
-                _logger.debug(__('Rewritten URL {0}', url_info))
+                if url_rewriter:
+                    # TODO: this logic should be a hook
+                    url_info = url_rewriter.rewrite(url_info)
+                    _logger.debug(__('Rewritten URL {0}', url_info))
 
-            yield url_info
+                yield url_info
+
+            except ValueError as e:
+                _logger.info(__('Invalid URL {0}: {1}', url_string, e))
 
     @classmethod
     def _input_file_as_lines(cls, session: AppSession):

--- a/wpull/document/htmlparse/html5lib_.py
+++ b/wpull/document/htmlparse/html5lib_.py
@@ -4,7 +4,6 @@ import html5lib.tokenizer
 import io
 import os.path
 
-from wpull.collections import FrozenDict, EmptyFrozenDict
 from wpull.document.htmlparse.base import BaseParser
 from wpull.document.htmlparse.element import Comment, Doctype, Element
 
@@ -45,11 +44,11 @@ class HTMLParser(BaseParser):
                     buffer = None
 
                 if tail_buffer:
-                    yield Element(tag, EmptyFrozenDict(), None, tail_buffer.getvalue(), True)
+                    yield Element(tag, dict(), None, tail_buffer.getvalue(), True)
                     tail_buffer = None
 
                 tag = token['name']
-                attrib = FrozenDict(dict(token['data']))
+                attrib = dict(token['data'])
                 buffer = io.StringIO()
 
                 if token['name'] == 'script':
@@ -67,7 +66,7 @@ class HTMLParser(BaseParser):
                     buffer = None
 
                 if tail_buffer:
-                    yield Element(tag, EmptyFrozenDict(), None, tail_buffer.getvalue(), True)
+                    yield Element(tag, dict(), None, tail_buffer.getvalue(), True)
                     tail_buffer = None
 
                 tail_buffer = io.StringIO()
@@ -88,7 +87,7 @@ class HTMLParser(BaseParser):
             buffer = None
 
         if tail_buffer:
-            yield Element(tag, EmptyFrozenDict(), None, tail_buffer.getvalue(), True)
+            yield Element(tag, dict(), None, tail_buffer.getvalue(), True)
             tail_buffer = None
 
 

--- a/wpull/document/htmlparse/lxml_.py
+++ b/wpull/document/htmlparse/lxml_.py
@@ -3,7 +3,6 @@ import io
 
 import lxml.html
 
-from wpull.collections import EmptyFrozenDict, FrozenDict
 from wpull.document.htmlparse.base import BaseParser
 from wpull.document.htmlparse.element import Element, Comment
 from wpull.document.xml import XMLDetector
@@ -37,7 +36,7 @@ class HTMLParserTarget(object):
 
         if self.tail_buffer:
             self.callback(Element(
-                self.tag, EmptyFrozenDict(),
+                self.tag, dict(),
                 None,
                 self.tail_buffer.getvalue(),
                 True
@@ -45,7 +44,7 @@ class HTMLParserTarget(object):
             self.tail_buffer = None
 
         self.tag = tag
-        self.attrib = FrozenDict(attrib)
+        self.attrib = attrib
         self.buffer = io.StringIO()
 
     def data(self, data):
@@ -66,7 +65,7 @@ class HTMLParserTarget(object):
 
         if self.tail_buffer:
             self.callback(Element(
-                self.tag, EmptyFrozenDict(),
+                self.tag, dict(),
                 None,
                 self.tail_buffer.getvalue(),
                 True
@@ -90,7 +89,7 @@ class HTMLParserTarget(object):
 
         if self.tail_buffer:
             self.callback(Element(
-                self.tag, EmptyFrozenDict(),
+                self.tag, dict(),
                 None,
                 self.tail_buffer.getvalue(),
                 True

--- a/wpull/network/connection.py
+++ b/wpull/network/connection.py
@@ -467,8 +467,8 @@ class SSLConnection(Connection):
             sock = self.writer.transport.get_extra_info('ssl_object',
                 self.writer.transport.get_extra_info('socket'))
         except AttributeError as error:
-            raise ConnectionError('Could not create SSL connection: {error}'
-                                  .format(error=error)) from error
+            raise SSLVerificationError('Failed to establish SSL connection; '
+                                       'server unexpectedly closed') from error
 
         self._verify_cert(sock)
         return result

--- a/wpull/network/connection.py
+++ b/wpull/network/connection.py
@@ -463,7 +463,13 @@ class SSLConnection(Connection):
     @asyncio.coroutine
     def connect(self):
         result = yield from super().connect()
-        sock = self.writer.transport.get_extra_info('ssl_object', self.writer.transport.get_extra_info('socket'))
+        try:
+            sock = self.writer.transport.get_extra_info('ssl_object',
+                self.writer.transport.get_extra_info('socket'))
+        except AttributeError as error:
+            raise ConnectionError('Could not create SSL connection: {error}'
+                                  .format(error=error)) from error
+
         self._verify_cert(sock)
         return result
 

--- a/wpull/network/connection.py
+++ b/wpull/network/connection.py
@@ -311,6 +311,12 @@ class BaseConnection(object):
             raise SSLVerificationError(
                 '{name} certificate error: {error}'
                 .format(name=name, error=error)) from error
+        except AttributeError as error:
+            self.close()
+
+            raise NetworkError(
+                '{name} network error: connection closed unexpectedly: {error}'
+                .format(name=name, error=error)) from error
         except (socket.error, ssl.SSLError, OSError, IOError) as error:
             self.close()
             if isinstance(error, NetworkError):

--- a/wpull/protocol/http/web.py
+++ b/wpull/protocol/http/web.py
@@ -88,9 +88,9 @@ class WebSession(object):
             else:
                 error = False
 
-            self._current_session.recycle()
             self._current_session.event_dispatcher.notify(
                 self._current_session.SessionEvent.end_session, error=error)
+            self._current_session.recycle()
 
     @asyncio.coroutine
     def start(self):
@@ -129,8 +129,6 @@ class WebSession(object):
         '''
         yield from \
             self._current_session.download(file, duration_timeout=duration_timeout)
-
-        self._current_session = None
 
     def _process_response(self, response: Response):
         '''Handle the response and update the internal state.'''

--- a/wpull/protocol/http/web.py
+++ b/wpull/protocol/http/web.py
@@ -82,8 +82,15 @@ class WebSession(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self._current_session:
             if not isinstance(exc_val, StopIteration):
+                _logger.debug('Early close session.')
+                error = True
                 self._current_session.abort()
+            else:
+                error = False
+
             self._current_session.recycle()
+            self._current_session.event_dispatcher.notify(
+                self._current_session.SessionEvent.end_session, error=error)
 
     @asyncio.coroutine
     def start(self):

--- a/wpull/proxy/server.py
+++ b/wpull/proxy/server.py
@@ -98,7 +98,6 @@ class HTTPProxySession(HookableMixin):
         self._http_client = http_client
         self._reader = self._original_reader = reader
         self._writer = self._original_writer = writer
-        self._is_tunnel = False
         self._is_ssl_tunnel = False
 
         self._cert_filename = wpull.util.get_package_filename('proxy/proxy.crt')
@@ -130,7 +129,7 @@ class HTTPProxySession(HookableMixin):
         _logger.debug(__('Got request {0}', request))
 
         if request.method == 'CONNECT':
-            yield from self._start_connect_tunnel()
+            self._reject_request('CONNECT is intentionally not supported')
             return
 
         if self._is_ssl_tunnel and request.url.startswith('http://'):
@@ -202,117 +201,6 @@ class HTTPProxySession(HookableMixin):
             self.event_dispatcher.notify(self.Event.server_end_response, response)
 
         _logger.debug('Response done.')
-
-    @asyncio.coroutine
-    def _start_connect_tunnel(self):
-        if self._is_tunnel:
-            self._reject_request('Cannot CONNECT within CONNECT')
-            return
-
-        self._is_tunnel = True
-
-        original_socket = yield from self._detach_socket_and_start_tunnel()
-        is_ssl = yield from self._is_client_request_ssl(original_socket)
-
-        if is_ssl:
-            _logger.debug('Tunneling as SSL')
-            yield from self._start_ssl_tunnel()
-        else:
-            yield from self._rewrap_socket(original_socket)
-
-    @classmethod
-    @asyncio.coroutine
-    def _is_client_request_ssl(cls, socket_: socket.socket) -> bool:
-        while True:
-            original_timeout = socket_.gettimeout()
-            socket_.setblocking(False)
-
-            try:
-                data = socket_.recv(3, socket.MSG_PEEK)
-            except OSError as error:
-                if error.errno in (errno.EWOULDBLOCK, errno.EAGAIN):
-                    yield from asyncio.sleep(0.01)
-                else:
-                    raise
-            else:
-                break
-            finally:
-                socket_.settimeout(original_timeout)
-
-        _logger.debug('peeked data %s', data)
-        if all(ord('A') <= char_code <= ord('Z') for char_code in data):
-            return False
-        else:
-            return True
-
-    @asyncio.coroutine
-    def _start_ssl_tunnel(self):
-        '''Start SSL protocol on the socket.'''
-
-        self._is_ssl_tunnel = True
-        ssl_socket = yield from self._start_ssl_handshake()
-        yield from self._rewrap_socket(ssl_socket)
-
-    @asyncio.coroutine
-    def _detach_socket_and_start_tunnel(self) -> socket.socket:
-        socket_ = self._writer.get_extra_info('socket')
-
-        try:
-            asyncio.get_event_loop().remove_reader(socket_.fileno())
-        except ValueError as error:
-            raise ConnectionAbortedError() from error
-
-        self._writer.write(b'HTTP/1.1 200 Connection established\r\n\r\n')
-        yield from self._writer.drain()
-
-        try:
-            asyncio.get_event_loop().remove_writer(socket_.fileno())
-        except ValueError as error:
-            raise ConnectionAbortedError() from error
-
-        return socket_
-
-    @asyncio.coroutine
-    def _start_ssl_handshake(self):
-        socket_ = self._writer.get_extra_info('socket')
-
-        ssl_socket = ssl.wrap_socket(
-            socket_, server_side=True,
-            certfile=self._cert_filename,
-            keyfile=self._key_filename,
-            do_handshake_on_connect=False
-        )
-
-        # FIXME: this isn't how to START TLS
-        for dummy in range(1200):
-            try:
-                ssl_socket.do_handshake()
-                break
-            except ssl.SSLError as error:
-                if error.errno in (ssl.SSL_ERROR_WANT_READ, ssl.SSL_ERROR_WANT_WRITE):
-                    _logger.debug('Do handshake %s', error)
-                    yield from asyncio.sleep(0.05)
-                else:
-                    raise
-        else:
-            _logger.error(_('Unable to handshake.'))
-            ssl_socket.close()
-            self._reject_request('Could not start TLS')
-            raise ConnectionAbortedError('Could not start TLS')
-
-        return ssl_socket
-
-    @asyncio.coroutine
-    def _rewrap_socket(self, new_socket):
-        loop = asyncio.get_event_loop()
-        reader = asyncio.StreamReader(loop=loop)
-        protocol = asyncio.StreamReaderProtocol(reader, loop=loop)
-        transport, dummy = yield from loop.create_connection(
-            lambda: protocol, sock=new_socket)
-        writer = asyncio.StreamWriter(transport, protocol, reader, loop)
-
-        self._reader = reader
-        self._writer = writer
 
     @asyncio.coroutine
     def _read_request_header(self) -> Request:

--- a/wpull/scraper/html.py
+++ b/wpull/scraper/html.py
@@ -20,7 +20,7 @@ _ = gettext.gettext
 _logger = StyleAdapter(logging.getLogger(__name__))
 
 
-LinkInfo = collections.namedtuple(
+_BaseLinkInfo = collections.namedtuple(
     'LinkInfoType',
     [
         'element', 'tag', 'attrib', 'link',
@@ -28,7 +28,15 @@ LinkInfo = collections.namedtuple(
         'link_type'
     ]
 )
-'''Information about a link in a lxml document.
+
+class LinkInfo(_BaseLinkInfo):
+    def __hash__(self):
+        return self.link.__hash__()
+
+    def __eq__(self, other):
+        return self.link.__eq__(other['link'])
+
+'''Information about a link in a lxml document.  Comparable on link only.
 
 Attributes:
     element: An instance of :class:`.document.HTMLReadElement`.

--- a/wpull/scraper/html.py
+++ b/wpull/scraper/html.py
@@ -33,9 +33,6 @@ class LinkInfo(_BaseLinkInfo):
     def __hash__(self):
         return self.link.__hash__()
 
-    def __eq__(self, other):
-        return self.link.__eq__(other['link'])
-
 '''Information about a link in a lxml document.  Comparable on link only.
 
 Attributes:

--- a/wpull/url.py
+++ b/wpull/url.py
@@ -431,7 +431,10 @@ def normalize(url, **kwargs):
 @functools.lru_cache()
 def normalize_hostname(hostname):
     '''Normalizes a hostname so that it is ASCII and valid domain name.'''
-    new_hostname = hostname.encode('idna').decode('ascii').lower()
+    try:
+        new_hostname = hostname.encode('idna').decode('ascii').lower()
+    except UnicodeError as error:
+        raise UnicodeError('Hostname {} rejected: {}'.format(hostname, error)) from error
 
     if hostname != new_hostname:
         # Check for round-trip. May raise UnicodeError

--- a/wpull/url.py
+++ b/wpull/url.py
@@ -123,6 +123,9 @@ class URLInfo(object):
     @functools.lru_cache()
     def parse(cls, url, default_scheme='http', encoding='utf-8'):
         '''Parse a URL and return a URLInfo.'''
+        if url is None:
+            return None
+
         url = url.strip()
         if frozenset(url) & C0_CONTROL_SET:
             raise ValueError('URL contains control codes: {}'.format(ascii(url)))

--- a/wpull/version.py
+++ b/wpull/version.py
@@ -32,5 +32,5 @@ def get_version_tuple(string):
     return major, minor, patch, level, serial
 
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 version_info = get_version_tuple(__version__)

--- a/wpull/version.py
+++ b/wpull/version.py
@@ -32,5 +32,5 @@ def get_version_tuple(string):
     return major, minor, patch, level, serial
 
 
-__version__ = '2.0.1'
+__version__ = '2.0.1a'
 version_info = get_version_tuple(__version__)

--- a/wpull/version.py
+++ b/wpull/version.py
@@ -32,5 +32,5 @@ def get_version_tuple(string):
     return major, minor, patch, level, serial
 
 
-__version__ = '2.0.1a'
+__version__ = '2.0.2'
 version_info = get_version_tuple(__version__)


### PR DESCRIPTION
Fixes issues #334, #345, and #347.

Changes handle two AttributeError exceptions thrown from inside asyncio's SSL implementation as NetworkError, and fix the end item notification to the wpull writer.