### PR TITLE
URL priorisation, split meta WARCs, and miscellaneous bug fixes

### DIFF
--- a/doc/api/urlprioritiser.rst
+++ b/doc/api/urlprioritiser.rst
@@ -1,0 +1,10 @@
+.. This document was automatically generated.
+   DO NOT EDIT!
+
+:mod:`urlprioritiser` Module
+============================
+
+.. automodule:: wpull.urlprioritiser
+    :members:
+    :show-inheritance:
+    :undoc-members:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,8 +7,8 @@ Summary of notable changes.
 .. Take advice from http://keepachangelog.com/.
 
 
-Unreleased (fork by JustAnotherArchivist)
-=========================================
+Unreleased
+==========
 
 * Fixed: Plugins are now loaded early again, restoring behaviour in version 1.x and allowing plugins to override wpull components again.
 * Fixed: `--concurrent` option had no effect since version 2.0.
@@ -31,20 +31,24 @@ Any direct usage of the `ItemSource`, `Worker`, or `Producer` classes in `wpull.
 generation coroutines instead of items. The `Pipeline` and `PipelineSeries` classes in the same module are not affected.
 
 
-2.0.3 (2017-05-15, fork by falconkirtaran)
-==========================================
+2.0.3 (2017-05-15)
+==================
 
 * Removed: HTTP CONNECT support
 * Fixed: `ValueError` crash from URL parsing
 
+Note: This version was only available on the fork by falconkirtaran until 2018-10-10.
 
-2.0.2 (2017-01-12, fork by falconkirtaran)
-==========================================
+
+2.0.2 (2017-01-12)
+==================
 
 * Fixed: Deadlock when wpull is finished.
 * Fixed: `AttributeError` crash on some SSL connections.
 * Fixed: `--warc-max-size` option had no effect since version 2.0.
 * Fixed: `AttributeError` crash from asyncio reading from a closed connection.
+
+Note: This version was only available on the fork by falconkirtaran until 2018-10-10.
 
 
 2.0.1 (2016-06-21)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,6 +17,7 @@ Unreleased
 * Fixed: ASCII tab and newline characters are now stripped from URLs, as required by the URL Standard.
 * Fixed: Empty ports in URLs are now handled correctly, i.e. as if no colon appeared in the host.
 * Added: URL priorisation through `--priority-*` options and a `get_priority` hook.
+* Added: Meta WARC splitting whenever data WARCs are split using the `--warc-split-meta` option.
 * Changed: `wpull.pipeline.pipeline.ItemSource` now deals in item generation coroutines rather than items directly.
 
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,8 +7,44 @@ Summary of notable changes.
 .. Take advice from http://keepachangelog.com/.
 
 
-Unreleased
-==========
+Unreleased (fork by JustAnotherArchivist)
+=========================================
+
+* Fixed: Plugins are now loaded early again, restoring behaviour in version 1.x and allowing plugins to override wpull components again.
+* Fixed: `--concurrent` option had no effect since version 2.0.
+* Fixed: wpull no longer flattens consecutive slashes in the path component of URLs, in line with RFC 3986, related standards, and behaviour of other software (wget and browsers).
+* Fixed: Backslashes in URL paths are now treated like forward slashes in accordance with the URL Standard and behaviour of browsers.
+* Fixed: ASCII tab and newline characters are now stripped from URLs, as required by the URL Standard.
+* Fixed: Empty ports in URLs are now handled correctly, i.e. as if no colon appeared in the host.
+* Added: URL priorisation through `--priority-*` options and a `get_priority` hook.
+* Changed: `wpull.pipeline.pipeline.ItemSource` now deals in item generation coroutines rather than items directly.
+
+
+Backwards incompatibility
++++++++++++++++++++++++++
+
+Plugins are now loaded very early in the initialisation again (as in version 1.x). This means that the various components of wpull
+are not yet initialised at the time `WpullPlugin.activate()` is executed. Plugins written for versions 2.0 through 2.0.3 which use
+instances directly will need to be changed to instead replace the relevant class in WpullPlugin.app_session.factory.class_map`.
+
+Any direct usage of the `ItemSource`, `Worker`, or `Producer` classes in `wpull.pipeline.pipeline` has to be adapted to handle item
+generation coroutines instead of items. The `Pipeline` and `PipelineSeries` classes in the same module are not affected.
+
+
+2.0.3 (2017-05-15, fork by falconkirtaran)
+==========================================
+
+* Removed: HTTP CONNECT support
+* Fixed: `ValueError` crash from URL parsing
+
+
+2.0.2 (2017-01-12, fork by falconkirtaran)
+==========================================
+
+* Fixed: Deadlock when wpull is finished.
+* Fixed: `AttributeError` crash on some SSL connections.
+* Fixed: `--warc-max-size` option had no effect since version 2.0.
+* Fixed: `AttributeError` crash from asyncio reading from a closed connection.
 
 
 2.0.1 (2016-06-21)

--- a/doc/differences.rst
+++ b/doc/differences.rst
@@ -69,6 +69,8 @@ Missing in Wget
 * ``--proxy-server``
 * ``--proxy-server-address``
 * ``--proxy-server-port``
+* ``--priority-regex``: Control in which order the URLs are retrieved.
+* ``--priority-domain``
 * ``--phantomjs``
 * ``--phantomjs-exe``
 * ``--phantomjs-max-time``

--- a/doc/differences.rst
+++ b/doc/differences.rst
@@ -60,6 +60,7 @@ Missing in Wget
 * ``--no-use-internal-ca-certs``
 * ``--warc-append``
 * ``--warc-move``: Move WARC files out of the way for resuming a crashed crawl.
+* ``--warc-split-meta``
 * ``--page-requisites-level``: Prevent infinite downloading of misconfurged server resources such as HTML served under a image.
 * ``--sitemaps``: Discover more URLs.
 * ``--hostnames``: Wget simply matches the endings when using ``--domains`` instead of matching each part of the hostname.

--- a/doc/scripting_interfaces_include.rst
+++ b/doc/scripting_interfaces_include.rst
@@ -13,6 +13,9 @@
 :py:attr:`PluginFunctions.finishing_statistics <wpull.application.plugin.PluginFunctions.finishing_statistics>`
    event Interface: :py:meth:`StatsStopTask.plugin_finishing_statistics <wpull.application.tasks.stats.StatsStopTask.plugin_finishing_statistics>`
 
+:py:attr:`PluginFunctions.get_priority <wpull.application.plugin.PluginFunctions.get_priority>`
+   hook Interface: :py:meth:`URLPrioritiser.plugin_get_priority <wpull.urlprioritiser.URLPrioritiser.plugin_get_priority>`
+
 :py:attr:`PluginFunctions.get_urls <wpull.application.plugin.PluginFunctions.get_urls>`
    event Interface: :py:meth:`ProcessingRule.plugin_get_urls <wpull.processor.rule.ProcessingRule.plugin_get_urls>`
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -70,6 +70,17 @@ example, limit the recursion depth.
    move the files ``--warc-move``.
 
 
+Priorisation
+============
+
+With the ``--priority-regex`` and ``--priority-domain`` options, you can
+control in which order the URLs in the queue are downloaded. These options
+can be specified multiple times and are used in the given order. Each URL
+is checked against the list of priority rules, and the first matching rule
+sets the priority for the URL. The default priority (if no rule matches)
+is zero. The higher a URL's priority value is, the sooner it is processed.
+
+
 Proxied Services
 ================
 

--- a/requirements-sphinx.txt
+++ b/requirements-sphinx.txt
@@ -1,7 +1,7 @@
 # Should be the same for requirements.txt:
 chardet>=2.0.1,<=2.3
 dnspython3==1.12
-html5lib>=0.999,<1.0
+html5lib>=0.999,<=0.9999999
 # lxml>=3.1.0,<=3.5 # except for this because it requires building C libs
 namedlist>=1.3,<=1.7
 psutil>=2.0,<=4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Absolutely known to work versions only:
 chardet>=2.0.1,<=2.3
 dnspython3==1.12
-html5lib>=0.999,<1.0
+html5lib>=0.999,<=0.9999999
 lxml>=3.1.0,<=3.5
 namedlist>=1.3,<=1.7
 psutil>=2.0,<=4.2

--- a/wpull/application/builder.py
+++ b/wpull/application/builder.py
@@ -17,7 +17,7 @@ from wpull.application.tasks.network import NetworkSetupTask
 from wpull.application.tasks.plugin import PluginSetupTask
 from wpull.application.tasks.resmon import ResmonSetupTask, ResmonSleepTask
 from wpull.application.tasks.rule import URLFiltersSetupTask, \
-    URLFiltersPostURLImportSetupTask
+    URLFiltersPostURLImportSetupTask, URLPrioritiserSetupTask
 from wpull.application.tasks.sslcontext import SSLContextTask
 from wpull.application.tasks.stats import StatsStartTask, StatsStopTask
 from wpull.application.tasks.warc import WARCRecorderSetupTask, \
@@ -65,6 +65,7 @@ from wpull.scraper.sitemap import SitemapScraper
 from wpull.stats import Statistics
 from wpull.url import URLInfo
 from wpull.urlfilter import DemuxURLFilter
+from wpull.urlprioritiser import URLPrioritiser
 from wpull.urlrewrite import URLRewriter
 from wpull.waiter import LinearWaiter
 from wpull.warc.recorder import WARCRecorder
@@ -123,6 +124,7 @@ class Builder(object):
             'SitemapScraper': SitemapScraper,
             'Statistics': Statistics,
             'URLInfo': URLInfo,
+            'URLPrioritiser': URLPrioritiser,
             'URLTable': URLTableHookWrapper,
             'URLTableImplementation': SQLURLTable,
             'URLRewriter': URLRewriter,
@@ -160,6 +162,7 @@ class Builder(object):
             AppSource(app_session),
             [
                 LoggingSetupTask(),
+                PluginSetupTask(),
                 DatabaseSetupTask(),
                 ParserSetupTask(),
                 WARCVisitsTask(),
@@ -167,6 +170,7 @@ class Builder(object):
                 ResmonSetupTask(),
                 StatsStartTask(),
                 URLFiltersSetupTask(),
+                URLPrioritiserSetupTask(),
                 NetworkSetupTask(),
                 ClientSetupTask(),
                 WARCRecorderSetupTask(),
@@ -175,7 +179,6 @@ class Builder(object):
                 ProxyServerSetupTask(),
                 CoprocessorSetupTask(),
                 LinkConversionSetupTask(),
-                PluginSetupTask(),
                 InputURLTask(),
                 URLFiltersPostURLImportSetupTask(),
             ])
@@ -226,6 +229,7 @@ class Builder(object):
                 download_stop_pipeline, conversion_pipeline, app_stop_pipeline
             ))
         pipeline_series.concurrency_pipelines.add(download_pipeline)
+        pipeline_series.concurrency = self._args.concurrent
 
         return pipeline_series
 

--- a/wpull/application/hook_test.py
+++ b/wpull/application/hook_test.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from wpull.application.hook import HookDispatcher, HookAlreadyConnectedError, \
     HookDisconnected, EventDispatcher, HookableMixin
@@ -16,13 +16,19 @@ class MyClass(HookableMixin):
 
 
 class MyPlugin(WpullPlugin):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # TODO: Replace this mess with unittest.mock
+        self.hook_calls = []
+        self.event_notifications = []
+
     @event('event_test')
-    def my_event_test_callback(self):
-        pass
+    def my_event_test_callback(self, *args, **kwargs):
+        self.event_notifications.append((args, kwargs))
 
     @hook('hook_test')
-    def my_hook_test_callback(self):
-        pass
+    def my_hook_test_callback(self, *args, **kwargs):
+        self.hook_calls.append((args, kwargs))
 
 
 class MyPluginHookAsEvent(WpullPlugin):
@@ -81,6 +87,22 @@ class TestHook(AsyncTestCase):
 
         self.assertEqual(9, result)
 
+    def test_hook_dispatcher_connects_plugin_hook_on_register(self):
+        plugin = MyPlugin()
+
+        hook = HookDispatcher(plugins = [plugin])
+        hook.register('hook_test')
+        self.assertTrue(hook.is_connected('hook_test'))
+        hook.call('hook_test', 'arg1', 'arg2', kwarg1 = 'one', kwarg2 = 'two', kwarg3 = 'three')
+        self.assertEqual(plugin.hook_calls, [(('arg1', 'arg2'), {'kwarg1': 'one', 'kwarg2': 'two', 'kwarg3': 'three'})])
+
+        # Verify that this implicit connect doesn't happen without specifying the plugins
+        hook = HookDispatcher()
+        hook.register('hook_test')
+        self.assertFalse(hook.is_connected('hook_test'))
+        with self.assertRaises(HookDisconnected):
+            hook.call('hook_test', 'a')
+
     def test_event_dispatcher(self):
         event = EventDispatcher()
 
@@ -112,6 +134,19 @@ class TestHook(AsyncTestCase):
         event.remove_listener('a', callback1)
 
         event.unregister('a')
+
+    def test_event_dispatcher_adds_plugin_event_listener_on_register(self):
+        plugin = MyPlugin()
+
+        event = EventDispatcher(plugins = [plugin])
+        event.register('event_test')
+        event.notify('event_test', 'arg1', 'arg2', kwarg1 = 'one', kwarg2 = 'two', kwarg3 = 'three')
+        self.assertEqual(plugin.event_notifications, [(('arg1', 'arg2'), {'kwarg1': 'one', 'kwarg2': 'two', 'kwarg3': 'three'})])
+
+        event = EventDispatcher()
+        event.register('event_test')
+        event.notify('event_test', 'a')
+        self.assertEqual(plugin.event_notifications, [(('arg1', 'arg2'), {'kwarg1': 'one', 'kwarg2': 'two', 'kwarg3': 'three'})])
 
     def test_hook_as_event_dispatcher_transclusion(self):
         event_dispatcher = EventDispatcher()
@@ -147,3 +182,37 @@ class TestHook(AsyncTestCase):
 
         with self.assertRaises(RuntimeError):
             tester.connect_plugin(plugin)
+
+    def test_set_plugins(self):
+        plugin = MyPlugin()
+        MyClass.set_plugins([plugin])
+
+        try:
+            tester = MyClass()
+
+            tester.hook_dispatcher.call('hook_test', 'a', key = 'b')
+            self.assertEqual(plugin.hook_calls, [(('a',), {'key': 'b'})])
+            self.assertEqual(plugin.event_notifications, [])
+
+            tester.event_dispatcher.notify('event_test', 'c', key = 'd')
+            self.assertEqual(plugin.hook_calls, [(('a',), {'key': 'b'})])
+            self.assertEqual(plugin.event_notifications, [(('c',), {'key': 'd'})])
+        finally:
+            MyClass.set_plugins([])
+
+    def test_set_plugins_in_superclass(self):
+        plugin = MyPlugin()
+        HookableMixin.set_plugins([plugin])
+
+        try:
+            tester = MyClass()
+
+            tester.hook_dispatcher.call('hook_test', 'a', key = 'b')
+            self.assertEqual(plugin.hook_calls, [(('a',), {'key': 'b'})])
+            self.assertEqual(plugin.event_notifications, [])
+
+            tester.event_dispatcher.notify('event_test', 'c', key = 'd')
+            self.assertEqual(plugin.hook_calls, [(('a',), {'key': 'b'})])
+            self.assertEqual(plugin.event_notifications, [(('c',), {'key': 'd'})])
+        finally:
+            HookableMixin.set_plugins([])

--- a/wpull/application/options.py
+++ b/wpull/application/options.py
@@ -4,6 +4,7 @@ import argparse
 import gettext
 import logging
 import os
+import re
 import ssl
 import sys
 
@@ -84,6 +85,28 @@ class AppHelpFormatter(argparse.HelpFormatter):
                 if action.option_strings or action.nargs in defaulting_nargs:
                     help += _(' (default: %(default)s)')
         return help
+
+
+class AppendPriorityFilterAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string):
+        if option_string == '--priority-regex':
+            filterType = 'regex'
+            try:
+                re.compile(values[0])
+            except re.error:
+                raise ValueError('invalid regular expression {s!r}'.format(values[0]))
+            filterArg = values[0]
+            filterPriority = int(values[1])
+        elif option_string == '--priority-domain':
+            filterType = 'domain'
+            filterArg = values[0] #TODO: Check if it's a valid domain name?
+            filterPriority = int(values[1])
+        else:
+            raise ValueError('unknown option string {s!r}'.format(option_string))
+
+        filterList = getattr(namespace, self.dest, [])
+        filterList.append((filterType, filterArg, filterPriority))
+        setattr(namespace, self.dest, filterList)
 
 
 class AppArgumentParser(argparse.ArgumentParser):
@@ -205,6 +228,7 @@ class AppArgumentParser(argparse.ArgumentParser):
         self._add_recursive_args()
         self._add_accept_args()
         self._add_proxy_server_args()
+        self._add_priority_args()
         self._add_phantomjs_args()
         self._add_youtube_dl_args()
 
@@ -1091,6 +1115,12 @@ class AppArgumentParser(argparse.ArgumentParser):
             default=os.curdir,
             help=_('use temporary DIRECTORY for preparing WARC files'),
         )
+        group.add_argument(
+            '--warc-split-meta',
+            action = 'store_true',
+            default = False,
+            help = _('split the log WARC along with the data WARC'),
+        )
 
     def _add_recursive_args(self):
         group = self.add_argument_group(_('recursion'))
@@ -1302,6 +1332,26 @@ class AppArgumentParser(argparse.ArgumentParser):
             metavar='PORT',
             help=_('bind the proxy server port to PORT')
         )
+
+    def _add_priority_args(self):
+        group = self.add_argument_group(_('priorisation'))
+        group.add_argument(
+            '--priority-regex',
+            nargs = 2,
+            metavar = ('REGEX', 'PRIORITY'),
+            dest = 'priority_filters',
+            action = AppendPriorityFilterAction,
+            help = _('assign PRIORITY to URLs matching REGEX'),
+        )
+        group.add_argument(
+            '--priority-domain',
+            nargs = 2,
+            metavar = ('DOMAIN', 'PRIORITY'),
+            dest = 'priority_filters',
+            action = AppendPriorityFilterAction,
+            help = _('assign PRIORITY to URLs under DOMAIN'),
+        )
+        self.set_defaults(priority_filters = [])
 
     def _add_phantomjs_args(self):
         group = self.add_argument_group(_('PhantomJS'))

--- a/wpull/application/plugin.py
+++ b/wpull/application/plugin.py
@@ -125,5 +125,6 @@ class PluginFunctions(enum.Enum):
     handle_pre_response = 'handle_pre_response'
     handle_error = 'handle_error'
     get_urls = 'get_urls'
+    get_priority = 'get_priority'
     finishing_statistics = 'finishing_statistics'
     exit_status = 'exit_status'

--- a/wpull/application/plugins/download_progress.plugin.py
+++ b/wpull/application/plugins/download_progress.plugin.py
@@ -36,17 +36,17 @@ class DownloadProgressPlugin(WpullPlugin):
             self._attach_event_listeners()
 
     def _attach_event_listeners(self):
-        http_client = cast(HTTPClient, self.app_session.factory['HTTPClient'])
-        http_client.event_dispatcher.add_listener(
-            HTTPClient.ClientEvent.new_session,
-            self._http_session_callback
-        )
+        class ProgressHTTPClient(self.app_session.factory.class_map['HTTPClient']):
+            def __init__(client_self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                client_self.event_dispatcher.add_listener(client_self.ClientEvent.new_session, self._http_session_callback)
+        self.app_session.factory.class_map['HTTPClient'] = ProgressHTTPClient
 
-        ftp_client = cast(FTPClient, self.app_session.factory['FTPClient'])
-        ftp_client.event_dispatcher.add_listener(
-            ftp_client.ClientEvent.new_session,
-            self._ftp_session_callback
-        )
+        class ProgressFTPClient(self.app_session.factory.class_map['FTPClient']):
+            def __init__(client_self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                client_self.event_dispatcher.add_listener(client_self.ClientEvent.new_session, self._ftp_session_callback)
+        self.app_session.factory.class_map['FTPClient'] = ProgressFTPClient
 
     def _http_session_callback(self, http_session: HTTPSession):
         http_session.event_dispatcher.add_listener(

--- a/wpull/application/tasks/plugin.py
+++ b/wpull/application/tasks/plugin.py
@@ -83,6 +83,8 @@ class PluginSetupTask(ItemTask[AppSession]):
         session.plugin_manager = PluginManager(plugin_locator=locator)
         session.plugin_manager.collectPlugins()
 
+        activated_plugins = []
+
         for plugin_info in session.plugin_manager.getAllPlugins():
             if plugin_info.path.startswith(internal_plugin_path):
                 _logger.debug(__(
@@ -102,6 +104,9 @@ class PluginSetupTask(ItemTask[AppSession]):
             if plugin_info.plugin_object.should_activate():
                 session.plugin_manager.activatePluginByName(plugin_info.name)
                 self._connect_plugin_hooks(session, plugin_info.plugin_object)
+                activated_plugins.append(plugin_info.plugin_object)
+
+        HookableMixin.set_plugins(activated_plugins)
 
     @classmethod
     def _get_candidate_instances(cls, session: AppSession):

--- a/wpull/application/tasks/rule.py
+++ b/wpull/application/tasks/rule.py
@@ -98,3 +98,27 @@ class URLFiltersPostURLImportSetupTask(ItemTask[AppSession]):
 
         demux_url_filter = session.factory['DemuxURLFilter']
         demux_url_filter.url_filters.append(span_hosts_filter)
+
+
+class URLPrioritiserSetupTask(ItemTask[AppSession]):
+    @asyncio.coroutine
+    def process(self, session: AppSession):
+        session.factory.new('URLPrioritiser', self._build_priorities(session))
+
+    @classmethod
+    def _build_priorities(cls, session: AppSession):
+        '''Create the URL filter instances.
+
+        Returns:
+            A list of URL filter instances
+        '''
+        args = session.args
+
+        filters = []
+        for filterType, filterArg, filterPriority in args.priority_filters:
+            if filterType == 'regex':
+                filters.append((RegexFilter(accepted = filterArg), filterPriority))
+            elif filterType == 'domain':
+                filters.append((BackwardDomainFilter(accepted = [filterArg]), filterPriority))
+
+        return filters

--- a/wpull/application/tasks/warc.py
+++ b/wpull/application/tasks/warc.py
@@ -67,6 +67,7 @@ class WARCRecorderSetupTask(ItemTask[AppSession]):
                 digests=args.warc_digests,
                 cdx=args.warc_cdx,
                 max_size=args.warc_max_size,
+                split_meta = args.warc_split_meta,
                 move_to=args.warc_move,
                 url_table=url_table,
                 software_string=software_string,

--- a/wpull/database/sqlmodel.py
+++ b/wpull/database/sqlmodel.py
@@ -88,7 +88,7 @@ class QueuedURL(DBBase):
         doc='Expected content type of extracted link.'
     )
     priority = Column(
-        Integer, nullable=False, default=0,
+        Integer, nullable=False, default=0, index = True,
         doc='Priority of item.'
     )
 

--- a/wpull/database/sqltable.py
+++ b/wpull/database/sqltable.py
@@ -46,7 +46,7 @@ class BaseSQLURLTable(BaseURLTable):
 
     def get_one(self, url):
         with self._session() as session:
-            result = session.query(QueuedURL).filter_by(url=url).first()
+            result = session.query(QueuedURL).filter_by(url=url).order_by(QueuedURL.priority.desc(), QueuedURL.id).first()
 
             if not result:
                 raise NotFound()
@@ -138,13 +138,13 @@ class BaseSQLURLTable(BaseURLTable):
         with self._session() as session:
             if level is None:
                 url_record = session.query(QueuedURL).filter_by(
-                    status=filter_status.value).first()
+                    status=filter_status.value).order_by(QueuedURL.priority.desc(), QueuedURL.id).first()
             else:
                 url_record = session.query(QueuedURL)\
                     .filter(
                         QueuedURL.status == filter_status.value,
                         QueuedURL.level < level,
-                ).first()
+                ).order_by(QueuedURL.priority.desc(), QueuedURL.id).first()
 
             if not url_record:
                 raise NotFound()

--- a/wpull/pipeline/item.py
+++ b/wpull/pipeline/item.py
@@ -76,6 +76,7 @@ class URLProperties(URLDatabaseMixin):
                            'level', 'inline_level', 'link_type', 'priority')
 
     def __init__(self):
+        super().__init__()
         self.parent_url = None
         self.root_url = None
         self.status = None
@@ -105,6 +106,7 @@ class URLData(URLDatabaseMixin):
     database_attributes = ('post_data',)
 
     def __init__(self):
+        super().__init__()
         self.post_data = None
 
 
@@ -117,6 +119,7 @@ class URLResult(URLDatabaseMixin):
     database_attributes = ('status_code', 'filename')
 
     def __init__(self):
+        super().__init__()
         self.status_code = None
         self.filename = None
 
@@ -136,3 +139,20 @@ class URLRecord(URLProperties, URLData, URLResult):
         '''Return URL Info for this URL'''
         return URLInfo.parse(self.url)
 
+    @classmethod
+    def root_record(cls, url):
+        '''Generate a URLRecord instance for a root entry'''
+        record = cls()
+        record.url = url
+        record.parent_url = url
+        record.root_url = url
+        record.status = Status.todo
+        record.try_count = 0
+        record.level = 0
+        record.inline_level = None
+        record.link_type = None
+        record.priority = None
+        record.post_data = None
+        record.status_code = None
+        record.filename = None
+        return record

--- a/wpull/pipeline/pipeline.py
+++ b/wpull/pipeline/pipeline.py
@@ -10,29 +10,60 @@ from wpull.backport.logging import BraceMessage as __
 
 _logger = logging.getLogger(__name__)
 
-POISON_PILL = object()
+class _PoisonPill:
+    pass
+POISON_PILL = _PoisonPill()
 ITEM_PRIORITY = 1
 POISON_PRIORITY = 0
+
+
+@asyncio.coroutine
+def poison_pill_coro():
+    return POISON_PILL
 
 
 WorkItemT = TypeVar('WorkItemT')
 
 
 class ItemTask(Generic[WorkItemT], metaclass=abc.ABCMeta):
+    '''A class representing a task to be performed on an item.'''
+
     @abc.abstractmethod
     @asyncio.coroutine
     def process(self, work_item: WorkItemT):
+        '''Perform the task.
+
+        Args:
+            work_item: The item to be processed.
+        '''
         pass
 
 
 class ItemSource(Generic[WorkItemT], metaclass=abc.ABCMeta):
+    '''An object generating new items for the pipeline.'''
+
     @abc.abstractmethod
     @asyncio.coroutine
     def get_item(self) -> Optional[WorkItemT]:
+        '''Generate an item
+
+        Returns:
+           An item to be processed through the pipeline using this ItemSource, or None if there are currently no items.
+        '''
         pass
 
 
 class ItemQueue(Generic[WorkItemT]):
+    '''A queue of items
+
+    This queue deals in coroutines. Add a coroutine returning an item to the queue with put_item_coro(), and retrieve it with get().
+
+    put_item_coro() also expects a producer future, which will be cancelled if the queue is drain()ed before the item is retrieved with get() to forward this information to the producer.
+    (The future is never marked as done by the queue; the item coroutine should do that.)
+
+    In addition, the queue allows adding poison pills with put_poison_nowait(), which will take preference over any item currently in the queue. Poison pills are not counted as items.
+    '''
+
     def __init__(self):
         self._queue = asyncio.PriorityQueue()
         self._unfinished_items = 0
@@ -40,32 +71,34 @@ class ItemQueue(Generic[WorkItemT]):
         self._entry_count = 0
 
     @asyncio.coroutine
-    def put_item(self, item: WorkItemT):
+    def put_item_coro(self, item_coro: WorkItemT, producer_future: asyncio.Future):
+        '''Push a new item along with its producer future to the queue. If the queue is currently non-empty, wait until it becomes empty before adding the item.'''
         while self._queue.qsize() > 0:
-            yield from self._worker_ready_condition.acquire()
-            yield from self._worker_ready_condition.wait()
-            self._worker_ready_condition.release()
+            yield from self.wait_for_worker()
 
         self._unfinished_items += 1
-        self._queue.put_nowait((ITEM_PRIORITY, self._entry_count, item))
+        self._queue.put_nowait((ITEM_PRIORITY, self._entry_count, item_coro, producer_future))
         self._entry_count += 1
 
     def put_poison_nowait(self):
-        self._queue.put_nowait((POISON_PRIORITY, self._entry_count, POISON_PILL))
+        '''Put a poison pill in the queue.'''
+        self._queue.put_nowait((POISON_PRIORITY, self._entry_count, poison_pill_coro, None))
         self._entry_count += 1
 
     @asyncio.coroutine
     def get(self) -> WorkItemT:
-        priority, entry_count, item = yield from self._queue.get()
+        '''Retrieve an item coroutine from the queue. This function will wait for an item coroutine if the queue is currently empty.'''
+        priority, entry_count, item_coro, producer_future = yield from self._queue.get()
 
         yield from self._worker_ready_condition.acquire()
         self._worker_ready_condition.notify_all()
         self._worker_ready_condition.release()
 
-        return item
+        return item_coro
 
     @asyncio.coroutine
     def item_done(self):
+        '''Mark an item as done. This shall be called by the caller of get() exactly once per item.'''
         self._unfinished_items -= 1
         assert self._unfinished_items >= 0
 
@@ -75,16 +108,30 @@ class ItemQueue(Generic[WorkItemT]):
 
     @property
     def unfinished_items(self) -> int:
+        '''The number of currently unfinished items.'''
         return self._unfinished_items
 
     @asyncio.coroutine
     def wait_for_worker(self):
+        '''Wait until a worker gets an item from the queue or marks an item as done.'''
         yield from self._worker_ready_condition.acquire()
         yield from self._worker_ready_condition.wait()
         self._worker_ready_condition.release()
 
+    @asyncio.coroutine
+    def drain(self):
+        '''Drain the queue: remove all items from the queue, consider them as completed, and cancel the producer futures.'''
+        while self._queue.qsize() > 0:
+            priority, entry_count, item_coro, producer_future = yield from self._queue.get()
+            yield from self.item_done()
+            if producer_future is not None:
+                producer_future.cancel()
+            _logger.debug('Drained {!r} ({!r}), {} remaining, {} unfinished'.format(item_coro, producer_future, self._queue.qsize(), self._unfinished_items))
+
 
 class Worker(object):
+    '''A worker or consumer of the item queue, performing a sequence of tasks on an item retrieved from the queue.'''
+
     def __init__(self, item_queue: ItemQueue, tasks: Sequence[ItemTask]):
         self._item_queue = item_queue
         self._tasks = tasks
@@ -92,14 +139,23 @@ class Worker(object):
 
     @asyncio.coroutine
     def process_one(self, _worker_id=None):
-        item = yield from self._item_queue.get()
+        '''Retrieve a single item from the queue, run it through all tasks, and return the item.'''
+        item_coro = yield from self._item_queue.get()
+        _logger.debug('worker {} processing {!r}'.format(_worker_id, item_coro))
+        item = yield from item_coro()
+        _logger.debug('worker {} got: {!r}'.format(_worker_id, item))
 
         if item == POISON_PILL:
+            return item
+
+        if item is None:
+            yield from self._item_queue.item_done()
             return item
 
         _logger.debug(__('Worker id {} Processing item {}', _worker_id, item))
 
         for task in self._tasks:
+            _logger.debug('Worker {} processing item {}, task {}'.format(_worker_id, item, task))
             yield from task.process(item)
 
         _logger.debug(__('Worker id {} Processed item {}', _worker_id, item))
@@ -110,6 +166,7 @@ class Worker(object):
 
     @asyncio.coroutine
     def process(self):
+        '''Run a worker loop until a poison pill is retrieved from the item queue.'''
         worker_id = self._worker_id_counter
         self._worker_id_counter += 1
 
@@ -124,34 +181,50 @@ class Worker(object):
 
 
 class Producer(object):
+    '''A producer of items, which puts (coroutines getting) items from the item_source into the item queue.'''
+
     def __init__(self, item_source: ItemSource, item_queue: ItemQueue):
         self._item_source = item_source
         self._item_queue = item_queue
         self._running = False
 
+    def _make_get_item_from_source(self, future):
+        @asyncio.coroutine
+        def _get_item_from_source():
+            _logger.debug('Get item from source')
+            item = yield from self._item_source.get_item()
+            future.set_result(item)
+            return item
+        return _get_item_from_source
+
     @asyncio.coroutine
     def process_one(self):
-        _logger.debug('Get item from source')
-        item = yield from self._item_source.get_item()
-
-        if item:
-            yield from self._item_queue.put_item(item)
-            return item
+        '''Put an item generation coroutine into the queue, wait until it is resolved (i.e. retrieved from the queue by a worker and yielded from), and return the resulting item or None if the item queue got drained before the item got processed.'''
+        future = asyncio.Future()
+        yield from self._item_queue.put_item_coro(self._make_get_item_from_source(future), future)
+        try:
+            item = yield from future
+        except asyncio.CancelledError:
+            item = None
+        return item
 
     @asyncio.coroutine
     def process(self):
+        '''Run the producer loop until there are no more items or stop() is called.'''
         self._running = True
 
         while self._running:
             item = yield from self.process_one()
 
-            if not item and self._item_queue.unfinished_items == 0:
-                self.stop()
-                break
-            elif not item:
-                yield from self._item_queue.wait_for_worker()
+            if item is None:
+                if self._item_queue.unfinished_items == 0:
+                    self.stop()
+                    break
+                else:
+                    yield from self._item_queue.wait_for_worker()
 
     def stop(self):
+        '''Stop the producer.'''
         if self._running:
             _logger.debug('Producer stopping.')
             self._running = False
@@ -164,6 +237,8 @@ class PipelineState(enum.Enum):
 
 
 class Pipeline(object):
+    '''A pipeline is a combination of an item source and a series of tasks. The items generated by the item source are processed by the tasks in the order given with support for parallelism.'''
+
     def __init__(self, item_source: ItemSource, tasks: Sequence[ItemTask],
                  item_queue: Optional[ItemQueue]=None):
         self._item_queue = item_queue or ItemQueue()
@@ -185,6 +260,9 @@ class Pipeline(object):
 
     @asyncio.coroutine
     def process(self):
+        '''Run the pipeline loop: start the producer if necessary, wait until the workers are done, shut down.'''
+        _logger.debug('pipeline processing: {!r}'.format(self._tasks))
+
         if self._state == PipelineState.stopped:
             self._state = PipelineState.running
             self._producer_task = asyncio.get_event_loop().create_task(self._run_producer_wrapper())
@@ -197,6 +275,7 @@ class Pipeline(object):
 
     @asyncio.coroutine
     def _process_one_worker(self):
+        '''Create the specified number of workers and wait until at least one of them finishes. Alternatively, if the concurrency is set to zero, wait until it is modified.'''
         assert self._state == PipelineState.running, self._state
 
         while len(self._worker_tasks) < self._concurrency:
@@ -219,6 +298,7 @@ class Pipeline(object):
 
     @asyncio.coroutine
     def _shutdown_processing(self):
+        '''Shut down the pipeline: wait for all workers to finish, drain the item queue, and wait for the producer to stop.'''
         assert self._state == PipelineState.stopping
 
         _logger.debug('Exited workers loop.')
@@ -226,16 +306,18 @@ class Pipeline(object):
         if self._worker_tasks:
             _logger.debug('Waiting for workers to stop.')
             yield from asyncio.wait(self._worker_tasks)
-
-        _logger.debug('Waiting for producer to stop.')
-
         self._worker_tasks.clear()
 
+        _logger.debug('Draining item queue')
+        yield from self._item_queue.drain()
+
+        _logger.debug('Waiting for producer to stop.')
         yield from self._producer_task
 
         self._state = PipelineState.stopped
 
     def stop(self):
+        '''Stop the pipeline.'''
         if self._state == PipelineState.running:
             self._state = PipelineState.stopping
             self._producer.stop()
@@ -257,6 +339,7 @@ class Pipeline(object):
             self.stop()
 
     def _kill_workers(self):
+        '''Kill the workers by putting a poison pill for each of them.'''
         for dummy in range(len(self._worker_tasks)):
             _logger.debug('Put poison pill.')
             self._item_queue.put_poison_nowait()
@@ -267,6 +350,7 @@ class Pipeline(object):
 
     @concurrency.setter
     def concurrency(self, new_concurrency: int):
+        '''Set the concurrency of this pipeline. The value has to be a non-negative integer. If zero, the pipeline is paused until the concurrency is modified again.'''
         if new_concurrency < 0:
             raise ValueError('Concurrency cannot be negative')
 
@@ -301,6 +385,8 @@ class Pipeline(object):
 
 
 class PipelineSeries(object):
+    '''A pipeline series is a sequence of pipelines to be processed in order. The concurrency is forwarded to all pipelines which are listed in concurrency_pipelines.'''
+
     def __init__(self, pipelines: Iterator[Pipeline]):
         self._pipelines = tuple(pipelines)
         self._concurrency = 1
@@ -316,6 +402,7 @@ class PipelineSeries(object):
 
     @concurrency.setter
     def concurrency(self, new_concurrency: int):
+        '''Set the concurrency for all pipelines in the concurrency_pipelines set.'''
         self._concurrency = new_concurrency
 
         for pipeline in self._pipelines:

--- a/wpull/pipeline/session.py
+++ b/wpull/pipeline/session.py
@@ -98,6 +98,15 @@ class ItemSession(object):
             return
 
         url_properties = url_properites or URLProperties()
+        if url_properties.priority is None:
+            prioritiser = self.app_session.factory['URLPrioritiser']
+            url_record = self.child_url_record(url,
+                                               inline = url_properties.inline_level is not None,
+                                               link_type = url_properties.link_type,
+                                               post_data = url_data.post_data,
+                                               level = url_properties.level)
+            url_properties.priority = prioritiser.get_priority(url_info, url_record)
+
         url_data = url_data or URLData()
         add_url_info = AddURLInfo(url, url_properties, url_data)
 
@@ -111,6 +120,7 @@ class ItemSession(object):
                       link_type: Optional[LinkType]=None,
                       post_data: Optional[str]=None,
                       level: Optional[int]=None,
+                      priority: Optional[int]=None,
                       replace: bool=False):
         '''Add links scraped from the document with automatic values.
 
@@ -139,6 +149,7 @@ class ItemSession(object):
         url_properties.parent_url = self.url_record.url
         url_properties.root_url = self.url_record.root_url or self.url_record.url
         url_properties.link_type = link_type
+        url_properties.priority = priority
         url_data = URLData()
         url_data.post_data = post_data
 

--- a/wpull/scraper/util.py
+++ b/wpull/scraper/util.py
@@ -72,7 +72,7 @@ def urljoin_safe(base_url, url, allow_fragments=True):
         str, None'''
     try:
         return wpull.url.urljoin(
-            base_url, url, allow_fragments=allow_fragments
+            base_url, url.translate({ord(c): None for c in '\r\n\t'}), allow_fragments=allow_fragments
         )
     except ValueError as error:
         _logger.warning(__(

--- a/wpull/scraper/util_test.py
+++ b/wpull/scraper/util_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from wpull.pipeline.item import LinkType
 from wpull.scraper.util import clean_link_soup, parse_refresh, is_likely_link, \
-    is_unlikely_link, identify_link_type
+    is_unlikely_link, identify_link_type, urljoin_safe
 
 
 class TestUtil(unittest.TestCase):
@@ -105,3 +105,9 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(LinkType.media, identify_link_type('hello.png'))
         self.assertEqual(LinkType.media, identify_link_type('hello.flv'))
         self.assertFalse(identify_link_type('hello.exe'))
+
+    def test_urljoin_safe(self):
+        self.assertEqual(
+            'https://example.com/foo/bar',
+            urljoin_safe('https://example.com/foo/baz', '\r\n\tba\t\nr')
+        )

--- a/wpull/testing/goodapp.py
+++ b/wpull/testing/goodapp.py
@@ -27,7 +27,7 @@ class IndexHandler(tornado.web.RequestHandler):
         self.write(page[10:])
 
 
-class BlogHandler(tornado.web.RequestHandler):
+class BlogHalf500Handler(tornado.web.RequestHandler):
     def initialize(self):
         if not hasattr(self.application, 'counter'):
             self.application.counter = 0
@@ -38,6 +38,15 @@ class BlogHandler(tornado.web.RequestHandler):
         if 1 <= page_num <= 5:
             if self.application.counter % 2 == 0:
                 raise HTTPError(500)
+            self.render('blog.html', page_num=page_num)
+        else:
+            raise HTTPError(404)
+
+
+class BlogHandler(tornado.web.RequestHandler):
+    def get(self):
+        page_num = int(self.get_argument('page', 1))
+        if 1 <= page_num <= 5:
             self.render('blog.html', page_num=page_num)
         else:
             raise HTTPError(404)
@@ -199,6 +208,7 @@ class GoodApp(tornado.web.Application):
     def __init__(self):
         tornado.web.Application.__init__(self, [
             (r'/', IndexHandler),
+            (r'/blog_half500/?', BlogHalf500Handler),
             (r'/blog/?', BlogHandler),
             (r'/infinite/', InfiniteHandler),
             (r'/static/(.*)', tornado.web.StaticFileHandler),

--- a/wpull/testing/integration/http_app_test.py
+++ b/wpull/testing/integration/http_app_test.py
@@ -91,7 +91,7 @@ class TestHTTPGoodApp(HTTPGoodAppTestCase):
     def test_many_page_with_some_fail(self):
         arg_parser = AppArgumentParser()
         args = arg_parser.parse_args([
-            self.get_url('/blog/'),
+            self.get_url('/blog_half500/'),
             '--no-parent',
             '--recursive',
             '--page-requisites',
@@ -518,7 +518,7 @@ class TestHTTPGoodApp(HTTPGoodAppTestCase):
     def test_quota(self):
         arg_parser = AppArgumentParser()
         args = arg_parser.parse_args([
-            self.get_url('/blog/'),
+            self.get_url('/blog_half500/'),
             '--recursive',
             '--quota', '1',
         ])

--- a/wpull/testing/integration/priorisation_test.py
+++ b/wpull/testing/integration/priorisation_test.py
@@ -1,0 +1,215 @@
+import gzip
+import os
+import unittest
+
+from wpull.application.builder import Builder
+from wpull.application.options import AppArgumentParser
+from wpull.errors import ExitStatus
+from wpull.testing.integration.base import HTTPGoodAppTestCase
+import wpull.testing.async
+from wpull.testing.integration.http_app_test import MockDNSResolver
+
+
+def setup_mock_web_client(builder, request_log):
+    class MockWebClient(builder.factory.class_map['WebClient']):
+        def session(self, request):
+            request_log.append(request)
+            return super().session(request)
+    builder.factory.class_map['WebClient'] = MockWebClient
+
+
+class TestPrioritiserHTTPGoodApp(HTTPGoodAppTestCase):
+    @wpull.testing.async.async_test()
+    def test_app_args_priority_regex(self):
+        arg_parser = AppArgumentParser()
+        args = arg_parser.parse_args([
+            self.get_url('/static/style.css'),
+            self.get_url('/static/mojibake.html'),
+            self.get_url('/static/DEUUEAUGH.html'),
+            self.get_url('/static/simple_javascript.html'),
+            '--priority-regex', r'/DEUUEAUGH\.html', '3',
+            '--priority-regex', r'/mojibake\.html', '2',
+            '--priority-regex', r'/simple_javascript\.html', '1',
+        ])
+        builder = Builder(args, unit_test=True)
+
+        request_log = []
+        setup_mock_web_client(builder, request_log)
+
+        app = builder.build()
+        exit_code = yield from app.run()
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual(builder.factory['Statistics'].files, 4)
+        self.assertEqual([r.resource_path for r in request_log], ['/static/DEUUEAUGH.html', '/static/mojibake.html', '/static/simple_javascript.html', '/static/style.css'])
+
+    @wpull.testing.async.async_test()
+    def test_app_args_priority_domain(self):
+        arg_parser = AppArgumentParser()
+        args = arg_parser.parse_args([
+            self.get_url('/static/style.css').replace('localhost', 'alpha.example.invalid'),
+            self.get_url('/static/mojibake.html').replace('localhost', 'beta.example.invalid'),
+            self.get_url('/static/DEUUEAUGH.html').replace('localhost', 'gamma.example.invalid'),
+            self.get_url('/static/simple_javascript.html').replace('localhost', 'delta.example.invalid'),
+            '--priority-domain', 'gamma.example.invalid', '3',
+            '--priority-domain', 'beta.example.invalid', '2',
+            '--priority-domain', 'delta.example.invalid', '1',
+        ])
+        builder = Builder(args, unit_test=True)
+        builder.factory.class_map['Resolver'] = MockDNSResolver
+
+        request_log = []
+        setup_mock_web_client(builder, request_log)
+
+        app = builder.build()
+        exit_code = yield from app.run()
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual(builder.factory['Statistics'].files, 4)
+        self.assertEqual([r.resource_path for r in request_log], ['/static/DEUUEAUGH.html', '/static/mojibake.html', '/static/simple_javascript.html', '/static/style.css'])
+
+    @wpull.testing.async.async_test()
+    def test_app_priority_recursive(self):
+        arg_parser = AppArgumentParser()
+        args = arg_parser.parse_args([
+            self.get_url('/blog/'),
+            '--no-robots',
+            '--recursive', '--level', 'inf',
+            '--page-requisites',
+            '--priority-regex', r'/blog/\?page=6', ' -1',
+            '--priority-regex', r'/blog/\?page=', '2',
+        ])
+        builder = Builder(args, unit_test=True)
+
+        request_log = []
+        setup_mock_web_client(builder, request_log)
+
+        app = builder.build()
+        exit_code = yield from app.run()
+
+        print(request_log)
+        self.assertEqual(0, exit_code)
+        self.assertEqual(builder.factory['Statistics'].files, 5)
+
+        self.assertEqual([r.resource_path for r in request_log], ['/blog/', '/blog/?page=2', '/blog/?page=3', '/blog/?page=4', '/blog/?page=5', '/stylesheet1.css', '/blog/?page=6'])
+
+    @wpull.testing.async.async_test()
+    def test_app_priority_plugin_get_urls(self):
+        filename = os.path.join(os.path.dirname(__file__), 'sample_user_scripts', 'priorisation.plugin.py')
+        arg_parser = AppArgumentParser()
+        args = arg_parser.parse_args([
+            self.get_url('/blog/'),
+            '--no-robots',
+            '--recursive', '--level', 'inf',
+            '--page-requisites',
+            '--priority-regex', r'/blog/\?page=6', ' -1',
+            '--priority-regex', r'/blog/\?.*&tab=', '3',
+            '--priority-regex', r'/blog/\?tab=', '1',
+            '--priority-regex', r'/blog/\?page=', '2',
+            '--plugin-script', filename,
+        ])
+        builder = Builder(args, unit_test=True)
+
+        request_log = []
+        setup_mock_web_client(builder, request_log)
+
+        app = builder.build()
+        exit_code = yield from app.run()
+
+        print(request_log)
+        self.assertEqual(0, exit_code)
+        self.assertEqual(builder.factory['Statistics'].files, 11)
+
+        self.assertEqual(
+            [r.resource_path for r in request_log],
+            [
+                '/blog/', # prio 0
+                '/blog/?page=2', # prio 2
+                '/blog/?page=3', # prio 2
+                '/blog/?page=3&tab=1', '/blog/?page=3&tab=2', '/blog/?page=3&tab=3', # prio 3
+                '/blog/?page=4', '/blog/?page=5', # prio 2
+                '/blog/?tab=1', '/blog/?tab=2', '/blog/?tab=3', # prio 1
+                '/stylesheet1.css', # prio 0
+                '/blog/?page=6', # prio -1
+            ]
+        )
+
+    @wpull.testing.async.async_test()
+    def test_app_priority_plugin_get_urls_with_priorities(self):
+        # Same as test_app_priority_plugin_get_urls, but with the priorities for the URLs added by the plugin set within the plugin rather than with --priority-* options
+        filename = os.path.join(os.path.dirname(__file__), 'sample_user_scripts', 'priorisation.plugin.py')
+        arg_parser = AppArgumentParser()
+        args = arg_parser.parse_args([
+            self.get_url('/blog/?get_urls_with_prio=1'), # Flag for the plugin to set priorities
+            '--no-robots',
+            '--recursive', '--level', 'inf',
+            '--page-requisites',
+            '--priority-regex', r'/blog/\?page=6', ' -1',
+            '--priority-regex', r'/blog/\?page=', '2',
+            '--plugin-script', filename,
+        ])
+        builder = Builder(args, unit_test=True)
+
+        request_log = []
+        setup_mock_web_client(builder, request_log)
+
+        app = builder.build()
+        exit_code = yield from app.run()
+
+        print(request_log)
+        self.assertEqual(0, exit_code)
+        self.assertEqual(builder.factory['Statistics'].files, 11)
+
+        self.assertEqual(
+            [r.resource_path for r in request_log],
+            [
+                '/blog/?get_urls_with_prio=1',
+                '/blog/?page=2',
+                '/blog/?page=3',
+                '/blog/?page=3&tab=1', '/blog/?page=3&tab=2', '/blog/?page=3&tab=3',
+                '/blog/?page=4', '/blog/?page=5',
+                '/blog/?tab=1', '/blog/?tab=2', '/blog/?tab=3',
+                '/stylesheet1.css',
+                '/blog/?page=6',
+            ]
+        )
+
+    @wpull.testing.async.async_test()
+    def test_app_priority_plugin_get_priority(self):
+        # Same as test_app_priority_plugin_get_urls_with_priorities, but with the priorities for the URLs added by the plugin in get_priority rather than in get_urls
+        filename = os.path.join(os.path.dirname(__file__), 'sample_user_scripts', 'priorisation.plugin.py')
+        arg_parser = AppArgumentParser()
+        args = arg_parser.parse_args([
+            self.get_url('/blog/?enable_get_priority=1'), # Flag for the plugin to activate get_priority hook
+            '--no-robots',
+            '--recursive', '--level', 'inf',
+            '--page-requisites',
+            '--priority-regex', r'/blog/\?page=6', ' -1',
+            '--priority-regex', r'/blog/\?page=', '2',
+            '--plugin-script', filename,
+        ])
+        builder = Builder(args, unit_test=True)
+
+        request_log = []
+        setup_mock_web_client(builder, request_log)
+
+        app = builder.build()
+        exit_code = yield from app.run()
+
+        print(request_log)
+        self.assertEqual(0, exit_code)
+        self.assertEqual(builder.factory['Statistics'].files, 11)
+
+        self.assertEqual(
+            [r.resource_path for r in request_log],
+            [
+                '/blog/?enable_get_priority=1',
+                '/blog/?page=2',
+                '/blog/?page=3',
+                '/blog/?page=3&tab=1', '/blog/?page=3&tab=2', '/blog/?page=3&tab=3',
+                '/blog/?page=4', '/blog/?page=5',
+                '/blog/?tab=1', '/blog/?tab=2', '/blog/?tab=3',
+                '/stylesheet1.css',
+                '/blog/?page=6',
+            ]
+        )

--- a/wpull/testing/integration/sample_user_scripts/priorisation.plugin.py
+++ b/wpull/testing/integration/sample_user_scripts/priorisation.plugin.py
@@ -1,0 +1,47 @@
+# encoding=utf-8
+import os.path
+
+from typing import cast, Optional
+
+from wpull.application.hook import Actions
+from wpull.application.plugin import WpullPlugin, hook, PluginFunctions, event
+from wpull.network.dns import ResolveResult
+from wpull.pipeline.app import AppSession
+from wpull.pipeline.item import URLRecord
+from wpull.pipeline.session import ItemSession
+from wpull.stats import Statistics
+from wpull.url import URLInfo
+from wpull.protocol.http.request import Response as HTTPResponse
+
+
+class Plugin(WpullPlugin):
+    def __init__(self):
+        self._set_priorities_in_get_urls = False
+        self._get_priority_enabled = False
+
+    @event(PluginFunctions.get_urls)
+    def get_urls(self, item_session: ItemSession):
+        filename = item_session.response.body.name
+        url_info = item_session.request.url_info
+
+        if url_info.resource == '/blog/?get_urls_with_prio=1':
+            self._set_priorities_in_get_urls = True
+        if url_info.resource == '/blog/?enable_get_priority=1':
+            self._get_priority_enabled = True
+
+        if url_info.resource in ('/blog/', '/blog/?get_urls_with_prio=1', '/blog/?enable_get_priority=1'):
+            for i in range(1, 4):
+                item_session.add_child_url('http://localhost:' + str(url_info.port) + '/blog/?tab=' + str(i), priority = 1 if self._set_priorities_in_get_urls else None)
+        elif url_info.resource == '/blog/?page=3':
+            for i in range(1, 4):
+                item_session.add_child_url('http://localhost:' + str(url_info.port) + '/blog/?page=3&tab=' + str(i), priority = 3 if self._set_priorities_in_get_urls else None)
+
+    @hook(PluginFunctions.get_priority)
+    def get_priority(self, url_info: URLInfo, url_record: URLRecord):
+        if not self._get_priority_enabled:
+            return None
+        if '?tab=' in url_info.resource:
+            return 1
+        if '?page=3&tab=' in url_info.resource:
+            return 3
+        return None

--- a/wpull/testing/integration/sample_user_scripts/stopper.plugin.py
+++ b/wpull/testing/integration/sample_user_scripts/stopper.plugin.py
@@ -1,10 +1,11 @@
 # encoding=utf-8
 from wpull.application.hook import Actions
 from wpull.application.plugin import WpullPlugin, PluginFunctions, hook
+from wpull.pipeline.session import ItemSession
 
 
 class MyPlugin(WpullPlugin):
     @hook(PluginFunctions.handle_response)
-    def stop(self):
+    def stop(self, item_session: ItemSession):
         print('stop')
         return Actions.STOP

--- a/wpull/testing/templates/blog.html
+++ b/wpull/testing/templates/blog.html
@@ -58,6 +58,6 @@
 	{% set rand = random.Random(page_num) %}
 	{% set dummy = rand.shuffle(l) %}
 	{{ ' '.join(l) }}
-	<a href="/blog/?page={{ page_num + 1}}">NEXT PAGE</a>
+	<a href="?page={{ page_num + 1}}">NEXT PAGE</a>
 </body>
 </htm>

--- a/wpull/url.py
+++ b/wpull/url.py
@@ -27,6 +27,9 @@ RELATIVE_SCHEME_DEFAULT_PORTS = {
     'wss': 443,
 }
 
+SPECIAL_SCHEMES = ['ftp', 'file', 'gopher', 'http', 'https', 'ws', 'wss']
+'''Special schemes as defined by the URL Standard'''
+
 C0_CONTROL_SET = frozenset(chr(i) for i in range(0, 0x1f + 1))
 '''Characters from 0x00 to 0x1f inclusive'''
 
@@ -127,6 +130,7 @@ class URLInfo(object):
             return None
 
         url = url.strip()
+        # TODO: \r\n\t should be removed from anywhere in the URL.
         if frozenset(url) & C0_CONTROL_SET:
             raise ValueError('URL contains control codes: {}'.format(ascii(url)))
 
@@ -164,11 +168,12 @@ class URLInfo(object):
             remaining = remaining[2:]
 
         path_index = remaining.find('/')
+        path_backslash_index = remaining.find('\\')
         query_index = remaining.find('?')
         fragment_index = remaining.find('#')
 
         try:
-            index_tuple = (path_index, query_index, fragment_index)
+            index_tuple = (path_index, path_backslash_index, query_index, fragment_index)
             authority_index = min(num for num in index_tuple if num >= 0)
         except ValueError:
             authority_index = len(remaining)
@@ -183,6 +188,11 @@ class URLInfo(object):
             path_index = len(remaining)
 
         path = remaining[authority_index + 1:path_index] or '/'
+
+        if scheme in SPECIAL_SCHEMES:
+            # Backslashes in the path of special URLs are treated like slashes
+            # except they cause a validation error, which is ignored.
+            path = path.replace('\\', '/')
 
         if fragment_index >= 0:
             query_index = fragment_index
@@ -244,9 +254,10 @@ class URLInfo(object):
             hostname, sep, port = host.rpartition(':')
 
         if sep:
-            port = int(port)
-            if port < 0 or port > 65535:
-                raise ValueError('Port number invalid')
+            if port != '':
+                port = int(port)
+                if port < 0 or port > 65535:
+                    raise ValueError('Port number invalid')
         else:
             hostname = port
             port = None
@@ -479,7 +490,7 @@ def normalize_path(path, encoding='utf-8'):
     '''
     if not path.startswith('/'):
         path = '/' + path
-    path = percent_encode(flatten_path(path, flatten_slashes=True), encoding=encoding)
+    path = percent_encode(flatten_path(path), encoding=encoding)
     return uppercase_percent_encoding(path)
 
 

--- a/wpull/url_test.py
+++ b/wpull/url_test.py
@@ -136,6 +136,14 @@ class TestURL(unittest.TestCase):
             'http://example.com/',
             URLInfo.parse('http://example.com:80').url
         )
+        self.assertEqual(
+            'http://example.com/',
+            URLInfo.parse('http://example.com:').url
+        )
+        self.assertEqual(
+            'http://example.com/',
+            URLInfo.parse('http://example.com:/').url
+        )
 
     def test_url_info_percent_encode(self):
         self.assertEqual(
@@ -253,8 +261,6 @@ class TestURL(unittest.TestCase):
         self.assertRaises(ValueError, URLInfo.parse, 'http:///horse')
         self.assertRaises(ValueError, URLInfo.parse, 'http://?what?')
         self.assertRaises(ValueError, URLInfo.parse, 'http://#egg=wpull')
-        self.assertRaises(ValueError, URLInfo.parse,
-                          'http://:@example.com:?@/')
         self.assertRaises(ValueError, URLInfo.parse, 'http://\x00/')
         self.assertRaises(ValueError, URLInfo.parse, 'http:/a')
         self.assertRaises(ValueError, URLInfo.parse, 'http://@@example.com/@')
@@ -368,8 +374,12 @@ class TestURL(unittest.TestCase):
             URLInfo.parse('http://:@example.com?@/').url
         )
         self.assertEqual(
-            'http://example.com/http:/example.com',
+            'http://example.com/http://example.com',
             URLInfo.parse('http://:@example.com/http://example.com').url
+        )
+        self.assertEqual(
+            'http://example.com/?@/',
+            URLInfo.parse('http://:@example.com:?@/').url
         )
 
     def test_url_info_query(self):
@@ -427,7 +437,7 @@ class TestURL(unittest.TestCase):
             URLInfo.parse('http://example.com.:81/').url
         )
 
-    def test_url_info_usrename_password(self):
+    def test_url_info_username_password(self):
         self.assertEqual(
             'http://UserName@example.com/',
             URLInfo.parse('http://UserName@example.com/').url
@@ -511,6 +521,28 @@ class TestURL(unittest.TestCase):
         self.assertEqual('https', url_info_dict['scheme'])
         self.assertEqual(443, url_info_dict['port'])
         self.assertEqual('utf-8', url_info_dict['encoding'])
+
+    def test_url_info_backslashes_in_path(self):
+        self.assertEqual(
+            'http://example.com/a/b/',
+            URLInfo.parse('http://example.com/a\\b/').url
+        )
+        self.assertEqual(
+            'http://example.com/a/b/',
+            URLInfo.parse('http://example.com/a\\b\\').url
+        )
+        self.assertEqual(
+            'http://example.com/a/b/',
+            URLInfo.parse('http://example.com\\a/b/').url
+        )
+        self.assertEqual(
+            'http://example.com/a///b/',
+            URLInfo.parse('http://example.com/a\\/\\b/').url
+        )
+        self.assertEqual(
+            'http://example.com/',
+            URLInfo.parse('http://example.com:\\').url
+        )
 
     def test_schemes_simialar(self):
         self.assertTrue(schemes_similar('http', 'http'))

--- a/wpull/urlprioritiser.py
+++ b/wpull/urlprioritiser.py
@@ -1,0 +1,60 @@
+import copy
+from typing import Iterator, Tuple, Union
+from wpull.application.plugin import PluginFunctions, hook_interface
+from wpull.application.hook import HookableMixin, HookDisconnected
+from wpull.pipeline.item import URLRecord
+from wpull.url import URLInfo
+from wpull.urlfilter import BaseURLFilter
+
+
+class URLPrioritiser(HookableMixin):
+    '''Uses multiple URL filters to determine a URL's priority.'''
+    def __init__(self, priorities: Iterator[Tuple[BaseURLFilter, int]]):
+        super().__init__()
+        self._priorities = priorities
+        self.hook_dispatcher.register(PluginFunctions.get_priority)
+
+    @property
+    def priorities(self) -> Iterator[Tuple[BaseURLFilter, int]]:
+        return self._priorities
+
+    @staticmethod
+    @hook_interface(PluginFunctions.get_priority)
+    def plugin_get_priority(url_info: URLInfo, url_record: URLRecord) -> Union[int, None]:
+        '''Return the priority for this URL.
+
+        Args:
+            url_info (URLInfo): A representation of the URL in question
+            url_record (URLRecord): Information about the URL in the context of the crawl.
+                Note that the priority attribute will always be ``None`` because the hook is called *before* the internal rules.
+
+        Returns:
+            An integer to set the priority to that value, or None if the normal priorisation rules shall be consulted.
+        '''
+        return None
+
+    def _get_priority_from_hook(self, url_info: URLInfo, url_record: URLRecord) -> Union[int, None]:
+        '''Tries to call the get_priority hook. The hook can either return an int or None. If the hook is not connected, None is retured.'''
+        try:
+            # Only pass copies of the URLInfo and URLRecord instances to the hook to prevent modification.
+            # A deep copy is not actually needed as of writing this code because all attributes of both classes are immutable.
+            # However, to prevent future breakage if something changes in those classes, a deep copy is used anyway.
+            priority = self.hook_dispatcher.call(PluginFunctions.get_priority, copy.deepcopy(url_info), copy.deepcopy(url_record))
+        except HookDisconnected:
+            priority = None
+        return priority
+
+    def _get_priority_from_filters(self, url_info: URLInfo, url_record: URLRecord) -> int:
+        '''Returns the priority for a URL based on the rules in self.priorities.'''
+
+        for url_filter, priority in self._priorities:
+            if url_filter.test(url_info, url_record):
+                return priority
+        return 0
+
+    def get_priority(self, url_info: URLInfo, url_record: URLRecord) -> int:
+        '''Returns the priority for a URL.'''
+        priority = self._get_priority_from_hook(url_info, url_record)
+        if priority is None:
+            priority = self._get_priority_from_filters(url_info, url_record)
+        return priority

--- a/wpull/urlprioritiser_test.py
+++ b/wpull/urlprioritiser_test.py
@@ -1,0 +1,71 @@
+# encoding=utf-8
+
+import unittest
+
+from wpull.application.plugin import PluginFunctions
+from wpull.pipeline.item import URLRecord
+from wpull.url import URLInfo
+from wpull.urlprioritiser import URLPrioritiser
+from wpull.urlfilter import RegexFilter
+
+
+PRIORITIES = [
+    (RegexFilter(accepted = r'//example\.com/'), 3),
+    (RegexFilter(accepted = r'^ftp://'), -1),
+    (RegexFilter(accepted = r'^https?://example\.net/critical/'), 2),
+    (RegexFilter(accepted = r'//example\.net/'), 1),
+]
+
+
+def build_hooked_prioritiser(hook_function):
+    class HookedURLPrioritiser(URLPrioritiser):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.hook_dispatcher.connect(PluginFunctions.get_priority, hook_function)
+    return HookedURLPrioritiser(PRIORITIES)
+
+
+class TestURLPrioritiser(unittest.TestCase):
+    def test_get_priority(self):
+        prioritiser = URLPrioritiser(PRIORITIES)
+
+        url_record = URLRecord()
+        self.assertEqual(prioritiser.get_priority(URLInfo.parse('https://example.com/foo.html'), url_record), 3)
+        self.assertEqual(prioritiser.get_priority(URLInfo.parse('ftp://example.com/bar'), url_record), 3)
+        self.assertEqual(prioritiser.get_priority(URLInfo.parse('https://example.net/critical/missile_codes'), url_record), 2)
+        self.assertEqual(prioritiser.get_priority(URLInfo.parse('https://example.net/baz'), url_record), 1)
+        self.assertEqual(prioritiser.get_priority(URLInfo.parse('https://example.org/'), url_record), 0)
+        self.assertEqual(prioritiser.get_priority(URLInfo.parse('ftp://example.net/baz'), url_record), -1)
+
+    def test_hook_simple(self):
+        hook_calls = []
+
+        def hook(url_info: URLInfo, url_record: URLRecord):
+            hook_calls.append((url_info, url_record))
+            return None
+
+        prioritiser = build_hooked_prioritiser(hook)
+
+        original_url_info = URLInfo.parse('https://example.com/foo.html')
+        original_url_record = URLRecord() # TODO: pass a proper URLRecord instead
+        self.assertEqual(prioritiser.get_priority(original_url_info, original_url_record), 3)
+        self.assertEqual(len(hook_calls), 1)
+        # Verify that the hook is called with a copy of the URLInfo and URLRecord instances
+        self.assertEqual(hook_calls[0][0], original_url_info)
+        self.assertIsNot(hook_calls[0][0], original_url_info)
+        #self.assertEqual(hook_calls[0][1], original_url_record) # TODO: URLRecord does not provide __eq__
+        self.assertIsNot(hook_calls[0][1], original_url_record)
+        self.assertIs(hook_calls[0][1].priority, None)
+
+    def test_hook_overrides(self):
+        def hook(url_info: URLInfo, url_record: URLRecord):
+            if url_info.url == 'https://example.com/bar':
+                return -10
+            return None
+
+        prioritiser = build_hooked_prioritiser(hook)
+
+        url_record = URLRecord()
+        self.assertEqual(prioritiser.get_priority(URLInfo.parse('https://example.com/foo.html'), url_record), 3)
+        self.assertEqual(prioritiser.get_priority(URLInfo.parse('https://example.com/bar'), url_record), -10)
+        self.assertEqual(prioritiser.get_priority(URLInfo.parse('https://example.com/baz'), url_record), 3)

--- a/wpull/warc/recorder.py
+++ b/wpull/warc/recorder.py
@@ -42,6 +42,7 @@ WARCRecorderParams = namedlist.namedtuple(
         ('digests', True),
         ('cdx', None),
         ('max_size', None),
+        ('split_meta', False),
         ('move_to', None),
         ('url_table', None),
         ('software_string', None)
@@ -60,6 +61,9 @@ Args:
     cdx (bool): If True, a CDX file will be written.
     max_size (int): If provided, output files are named like
         ``name-00000.ext`` and the log file will be in ``name-meta.ext``.
+    split_meta (bool): If True and max_size is set, the log WARC is split
+        together with the data WARC, producing pairs of ``name-#####.ext``
+        and ``name-#####-meta.ext``.
     move_to (str): If provided, completed WARC files and CDX files will be
         moved to the given directory
     url_table (:class:`.database.URLTable`): If given, then ``revist``
@@ -87,6 +91,7 @@ class WARCRecorder(object):
         self._prefix_filename = filename
         self._params = params or WARCRecorderParams()
         self._warcinfo_record = None
+        self._meta_sequence_num = 0
         self._sequence_num = 0
         self._log_temp_file = None
         self._log_handler = None
@@ -95,8 +100,8 @@ class WARCRecorder(object):
 
         self._check_journals_and_maybe_raise()
 
-        if params.log:
-            self._setup_log()
+        if self._params.log:
+            self._flush_log()
 
         self._start_new_warc_file()
 
@@ -112,13 +117,16 @@ class WARCRecorder(object):
 
     def _start_new_warc_file(self, meta=False):
         '''Create and set as current WARC file.'''
-        if self._params.max_size and not meta and self._params.appending:
+        if self._params.max_size and (not meta or self._params.split_meta) and self._params.appending:
             while True:
-                self._warc_filename = self._generate_warc_filename()
+                self._warc_filename = self._generate_warc_filename(meta = meta)
 
                 if os.path.exists(self._warc_filename):
                     _logger.debug('Skip {0}', self._warc_filename)
-                    self._sequence_num += 1
+                    if meta:
+                        self._meta_sequence_num += 1
+                    else:
+                        self._sequence_num += 1
                 else:
                     break
         else:
@@ -138,7 +146,10 @@ class WARCRecorder(object):
         if self._params.max_size is None:
             sequence_name = ''
         elif meta:
-            sequence_name = '-meta'
+            if self._params.split_meta:
+                sequence_name = '-{:05d}-meta'.format(self._meta_sequence_num)
+            else:
+                sequence_name = '-meta'
         else:
             sequence_name = '-{0:05d}'.format(self._sequence_num)
 
@@ -181,34 +192,81 @@ class WARCRecorder(object):
             bytes(info_fields) + b'\r\n')
         self._warcinfo_record.compute_checksum()
 
-    def _setup_log(self):
-        '''Set up the logging file.'''
+    def _flush_log(self, closing = False):
+        '''Flush the logging
+
+        If there is already a logger and we want to split the meta WARC: write a meta WARC, delete the temporary log, and move the meta WARC if necessary.
+        Then, set up the logger anew.
+
+        If closing is True (i.e. this is the last call to _flush_log), only write the meta WARC etc. and don't set up a new logger.
+
+        Note that the "write a meta WARC" part will have the side effect of setting self._warc_filename.
+        '''
         logger = logging.getLogger()
-        formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-        self._log_temp_file = NamedTemporaryFile(
-            prefix='tmp-wpull-warc-',
-            dir=self._params.temp_dir,
-            suffix='.log.gz',
-            delete=False,
-        )
-        self._log_temp_file.close()  # For Windows
+        if self._log_handler and (self._params.split_meta or closing):
+            self._log_handler.flush()
 
-        self._log_handler = handler = logging.StreamHandler(
-            io.TextIOWrapper(
-                gzip.GzipFile(
-                    filename=self._log_temp_file.name, mode='wb'
-                ),
-                encoding='utf-8'
+            logger.removeHandler(self._log_handler)
+            self._log_handler.stream.close()
+
+            log_record = WARCRecord()
+            log_record.block_file = gzip.GzipFile(
+                filename=self._log_temp_file.name
             )
-        )
+            log_record.set_common_fields('resource', 'text/plain')
 
-        logger.setLevel(logging.DEBUG)
-        logger.debug('Wpull needs the root logger level set to DEBUG.')
+            log_record.fields['WARC-Target-URI'] = \
+                'urn:X-wpull:log'
 
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-        handler.setLevel(logging.INFO)
+            if self._params.max_size is not None: # Only create a separate meta WARC if max_size is set
+                self._start_new_warc_file(meta=True)
+
+            self.set_length_and_maybe_checksums(log_record)
+            self.write_record(log_record)
+
+            log_record.block_file.close()
+
+            try:
+                os.remove(self._log_temp_file.name)
+            except OSError:
+                _logger.exception('Could not close log temp file.')
+
+            self._log_temp_file = None
+
+            self._log_handler.close()
+            self._log_handler = None
+
+            if self._params.move_to is not None:
+                self._move_file_to_dest_dir(self._warc_filename)
+
+            self._meta_sequence_num += 1
+
+        if not self._log_handler and not closing:
+            formatter = logging.Formatter(
+                '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            self._log_temp_file = NamedTemporaryFile(
+                prefix='tmp-wpull-warc-',
+                dir=self._params.temp_dir,
+                suffix='.log.gz',
+                delete=False,
+            )
+            self._log_temp_file.close()  # For Windows
+
+            self._log_handler = handler = logging.StreamHandler(
+                io.TextIOWrapper(
+                    gzip.GzipFile(
+                        filename=self._log_temp_file.name, mode='wb'
+                    ),
+                    encoding='utf-8'
+                )
+            )
+
+            logger.setLevel(logging.DEBUG)
+            logger.debug('Wpull needs the root logger level set to DEBUG.')
+
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+            handler.setLevel(logging.INFO)
 
     def listen_to_http_client(self, client: HTTPClient):
         client.event_dispatcher.add_listener(HTTPClient.ClientEvent.new_session,
@@ -285,6 +343,9 @@ class WARCRecorder(object):
 
             if self._params.move_to is not None:
                 self._move_file_to_dest_dir(self._warc_filename)
+
+            if self._params.log:
+                self._flush_log()
 
             _logger.debug('Starting new warc file due to max size.')
             self._start_new_warc_file()
@@ -364,45 +425,11 @@ class WARCRecorder(object):
 
     def close(self):
         '''Close the WARC file and clean up any logging handlers.'''
-        if self._log_temp_file:
-            self._log_handler.flush()
+        if self._params.max_size is not None and self._params.move_to is not None:
+            self._move_file_to_dest_dir(self._warc_filename)
 
-            logger = logging.getLogger()
-            logger.removeHandler(self._log_handler)
-            self._log_handler.stream.close()
-
-            log_record = WARCRecord()
-            log_record.block_file = gzip.GzipFile(
-                filename=self._log_temp_file.name
-            )
-            log_record.set_common_fields('resource', 'text/plain')
-
-            log_record.fields['WARC-Target-URI'] = \
-                'urn:X-wpull:log'
-
-            if self._params.max_size is not None:
-                if self._params.move_to is not None:
-                    self._move_file_to_dest_dir(self._warc_filename)
-
-                self._start_new_warc_file(meta=True)
-
-            self.set_length_and_maybe_checksums(log_record)
-            self.write_record(log_record)
-
-            log_record.block_file.close()
-
-            try:
-                os.remove(self._log_temp_file.name)
-            except OSError:
-                _logger.exception('Could not close log temp file.')
-
-            self._log_temp_file = None
-
-            self._log_handler.close()
-            self._log_handler = None
-
-            if self._params.move_to is not None:
-                self._move_file_to_dest_dir(self._warc_filename)
+        if self._params.log:
+            self._flush_log(closing = True)
 
         if self._cdx_filename and self._params.move_to is not None:
             self._move_file_to_dest_dir(self._cdx_filename)

--- a/wpull/warc/recorder_test.py
+++ b/wpull/warc/recorder_test.py
@@ -327,6 +327,138 @@ class TestWARC(unittest.TestCase, TempDirMixin):
         self.validate_warc('asdf-00001.warc')
         self.validate_warc('asdf-meta.warc')
 
+    def test_warc_recorder_max_size_split_meta(self):
+        file_prefix = 'asdf'
+        cdx_filename = 'asdf.cdx'
+
+        warc_recorder = WARCRecorder(
+            file_prefix,
+            params=WARCRecorderParams(
+                compress=False,
+                extra_fields=[('Extra-field', 'my_extra_field')],
+                cdx=True, max_size=1,
+                split_meta = True,
+            )
+        )
+
+        # This produces three data and meta WARCs (00000 to 00002). The reason being that a new WARC is started after the second request.
+        # That last WARC does not contain any data, but the third meta WARC contains the "FINISHED" log message.
+
+        _logger.info('Fetching http://example.com/1')
+        request = HTTPRequest('http://example.com/1')
+        request.address = ('0.0.0.0', 80)
+        response = HTTPResponse(200, 'OK')
+        response.body = Body()
+
+        with wpull.util.reset_file_offset(response.body):
+            response.body.write(b'KITTEH DOGE')
+
+        session = warc_recorder.new_http_recorder_session()
+        session.begin_request(request)
+        session.request_data(request.to_bytes())
+        session.end_request(request)
+        session.begin_response(response)
+        session.response_data(response.to_bytes())
+        session.response_data(response.body.content())
+        session.end_response(response)
+        _logger.info('Fetched http://example.com/1') # Note, the normal "Fetched" log message is also emitted before the session is closed. Otherwise, it'd end up in the next meta WARC.
+        session.close()
+
+        _logger.info('Fetching http://example.com/2')
+        request = HTTPRequest('http://example.com/2')
+        request.address = ('0.0.0.0', 80)
+        response = HTTPResponse(200, 'OK')
+        response.body = Body()
+
+        with wpull.util.reset_file_offset(response.body):
+            response.body.write(b'DOGE KITTEH')
+
+        session = warc_recorder.new_http_recorder_session()
+        session.begin_request(request)
+        session.request_data(request.to_bytes())
+        session.end_request(request)
+        session.begin_response(response)
+        session.response_data(response.to_bytes())
+        session.response_data(response.body.content())
+        session.end_response(response)
+        _logger.info('Fetched http://example.com/2')
+        session.close()
+
+        _logger.info('FINISHED')
+
+        warc_recorder.close()
+
+        self.assertTrue(os.path.exists('asdf-00000.warc'))
+        self.assertTrue(os.path.exists('asdf-00001.warc'))
+        self.assertTrue(os.path.exists('asdf-00002.warc'))
+        self.assertTrue(os.path.exists('asdf-00000-meta.warc'))
+        self.assertTrue(os.path.exists('asdf-00001-meta.warc'))
+        self.assertTrue(os.path.exists('asdf-00002-meta.warc'))
+        self.assertTrue(os.path.exists(cdx_filename))
+
+        with open('asdf-00000.warc', 'rb') as in_file:
+            warc_file_content = in_file.read()
+
+        self.assertTrue(warc_file_content.startswith(b'WARC/1.0'))
+        self.assertIn(b'WARC-Type: warcinfo', warc_file_content)
+        self.assertIn(b'KITTEH DOGE', warc_file_content)
+
+        with open('asdf-00001.warc', 'rb') as in_file:
+            warc_file_content = in_file.read()
+
+        self.assertTrue(warc_file_content.startswith(b'WARC/1.0'))
+        self.assertIn(b'WARC-Type: warcinfo', warc_file_content)
+        self.assertIn(b'DOGE KITTEH', warc_file_content)
+
+        with open('asdf-00002.warc', 'rb') as in_file:
+            warc_file_content = in_file.read()
+
+        self.assertTrue(warc_file_content.startswith(b'WARC/1.0'))
+        self.assertIn(b'WARC-Type: warcinfo', warc_file_content)
+        self.assertNotIn(b'WARC-Type: re', warc_file_content) # No request or response
+
+        with open(cdx_filename, 'rb') as in_file:
+            cdx_file_content = in_file.read()
+
+        cdx_lines = cdx_file_content.split(b'\n')
+        cdx_labels = cdx_lines[0].strip().split(b' ')
+
+        print(cdx_lines)
+
+        self.assertEqual(4, len(cdx_lines))
+        self.assertEqual(10, len(cdx_labels))
+
+        self.assertIn(b'http://example.com/1', cdx_file_content)
+        self.assertIn(b'http://example.com/2', cdx_file_content)
+
+        with open('asdf-00000-meta.warc', 'rb') as in_file:
+            meta_file_content = in_file.read()
+
+        self.assertIn(b'Fetching http://example.com/1', meta_file_content)
+        self.assertIn(b'Fetched http://example.com/1', meta_file_content)
+        self.assertNotIn(b'http://example.com/2', meta_file_content)
+        self.assertNotIn(b'FINISHED', meta_file_content)
+
+        with open('asdf-00001-meta.warc', 'rb') as in_file:
+            meta_file_content = in_file.read()
+
+        self.assertNotIn(b'http://example.com/1', meta_file_content)
+        self.assertIn(b'Fetching http://example.com/2', meta_file_content)
+        self.assertIn(b'Fetched http://example.com/2', meta_file_content)
+        self.assertNotIn(b'FINISHED', meta_file_content)
+
+        with open('asdf-00002-meta.warc', 'rb') as in_file:
+            meta_file_content = in_file.read()
+
+        self.assertIn(b'FINISHED', meta_file_content)
+
+        self.validate_warc('asdf-00000.warc')
+        self.validate_warc('asdf-00001.warc')
+        self.validate_warc('asdf-00002.warc')
+        self.validate_warc('asdf-00000-meta.warc')
+        self.validate_warc('asdf-00001-meta.warc')
+        self.validate_warc('asdf-00002-meta.warc')
+
     def test_warc_recorder_rollback(self):
         warc_filename = 'asdf.warc'
         warc_prefix = 'asdf'
@@ -592,6 +724,49 @@ class TestWARC(unittest.TestCase, TempDirMixin):
         self.assertTrue(os.path.exists('./blah/asdf-00000.warc'))
         self.assertTrue(os.path.exists('./blah/asdf-00001.warc'))
         self.assertTrue(os.path.exists('./blah/asdf-meta.warc'))
+        self.assertTrue(os.path.exists('./blah/' + cdx_filename))
+
+    def test_warc_move_max_size_split_meta(self):
+        file_prefix = 'asdf'
+        cdx_filename = 'asdf.cdx'
+
+        os.mkdir('./blah/')
+
+        warc_recorder = WARCRecorder(
+            file_prefix,
+            params=WARCRecorderParams(
+                compress=False,
+                cdx=True,
+                move_to='./blah/',
+                max_size=1,
+                split_meta = True,
+            ),
+        )
+
+        request = HTTPRequest('http://example.com/1')
+        request.address = ('0.0.0.0', 80)
+        response = HTTPResponse(200, 'OK')
+        response.body = Body()
+
+        with wpull.util.reset_file_offset(response.body):
+            response.body.write(b'BLAH')
+
+        session = warc_recorder.new_http_recorder_session()
+        session.begin_request(request)
+        session.request_data(request.to_bytes())
+        session.end_request(request)
+        session.begin_response(response)
+        session.response_data(response.to_bytes())
+        session.response_data(response.body.content())
+        session.end_response(response)
+        session.close()
+
+        warc_recorder.close()
+
+        self.assertTrue(os.path.exists('./blah/asdf-00000.warc'))
+        self.assertTrue(os.path.exists('./blah/asdf-00001.warc'))
+        self.assertTrue(os.path.exists('./blah/asdf-00000-meta.warc'))
+        self.assertTrue(os.path.exists('./blah/asdf-00001-meta.warc'))
         self.assertTrue(os.path.exists('./blah/' + cdx_filename))
 
     def test_warc_max_size_and_append(self):

--- a/wpull/writer.py
+++ b/wpull/writer.py
@@ -138,7 +138,12 @@ class BaseFileWriterSession(BaseWriterSession):
         try:
             last_modified = email.utils.parsedate(last_modified)
         except ValueError:
-            _logger.exception('Failed to parse date.')
+            _logger.exception('Failed to parse last-modified date.')
+            return
+
+        if last_modified is None:
+            # email.utils.parsedate returns None if parsing fails
+            _logger.error('Failed to parse last-modified date: {!r} -> None.'.format(response.fields.get('Last-Modified')))
             return
 
         last_modified = time.mktime(last_modified)


### PR DESCRIPTION
This PR contains the various things I've implemented and fixed back in January and February on my fork, listed below.

Sorry for the huge PR. I was working based on version 2.0.3 (then only available on FalconK's fork) back then, and separating this into individual PRs for each implemented feature/fixed bug now would be really painful. Let me know if you want me to do it anyway.

* Add URL priorisation: `--priority-regex`/`--priority-domain` and the `get_priority` hook can be used to determine in which order URLs are retrieved.
* Load plugins early again, like in wpull 1.x. Before, plugins were loaded after everything was already initialised, which made it difficult to replace functionality by replacing the factory class map. (Fixes #383)
* Rewrite parts of the pipeline code to fix the order of URLs; this wasn't really a problem before, but it messed with the priorisation code.
* Fix `--concurrent` having no effect (#339)
* Pin html5lib version (fixes #332)
* Add splitting meta WARCs when the data WARC is split using `--warc-split-meta`
* Fix flattening of consecutive slashes in URLs (#380)
* Handle backslashes in URLs (fixes #377)
* Handle invalid dates in last modified date (fixes #376)
* Strip tab and newline characters from scraped URLs (fixes #355)
* Handle empty port correctly (fixes #340)