### PR TITLE
follow tornado exception naming change

### DIFF
--- a/wpull/network/connection.py
+++ b/wpull/network/connection.py
@@ -10,7 +10,6 @@ import socket
 import ssl
 
 import tornado.netutil
-from tornado.netutil import SSLCertificateError
 from typing import Optional, Union
 from wpull.backport.logging import BraceMessage as __
 from wpull.errors import NetworkError, ConnectionRefused, SSLVerificationError, \
@@ -305,7 +304,7 @@ class BaseConnection(object):
             self.close()
             raise NetworkTimedOut(
                 '{name} timed out.'.format(name=name)) from error
-        except (tornado.netutil.SSLCertificateError, SSLVerificationError) \
+        except (ssl.CertificateError, SSLVerificationError) \
                 as error:
             self.close()
             raise SSLVerificationError(


### PR DESCRIPTION
SSLCertificateError was never part of the official tornado API and was
removed in v5. Instead of relying on that undocumented API, we use the
exception from the core `ssl` module which tornado now uses anyways.

Closes: #384

I remembered to:

* [x] Update or add unit tests if needed (tests should already be failing)
* [x] Update or add documentation/comments if needed (not needed)
* [x] Made sure stray files or whitespace didn't get committed
* [x] If significant changes, branch from `develop` and set to merge into `develop`
* [x] Read the guidelines for contributing