### PR TITLE
Pin html5lib version to 0.9999999 (seven nines) (closes #332)

### DIFF
--- a/requirements-sphinx.txt
+++ b/requirements-sphinx.txt
@@ -1,7 +1,7 @@
 # Should be the same for requirements.txt:
 chardet>=2.0.1,<=2.3
 dnspython3==1.12
-html5lib>=0.999,<1.0
+html5lib>=0.999,<=0.9999999
 # lxml>=3.1.0,<=3.5 # except for this because it requires building C libs
 namedlist>=1.3,<=1.7
 psutil>=2.0,<=4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Absolutely known to work versions only:
 chardet>=2.0.1,<=2.3
 dnspython3==1.12
-html5lib>=0.999,<1.0
+html5lib>=0.999,<=0.9999999
 lxml>=3.1.0,<=3.5
 namedlist>=1.3,<=1.7
 psutil>=2.0,<=4.2


### PR DESCRIPTION
Version 0.99999999 (eight nines) and up do not provide the `html5lib.tokenizer` API used by wpull.

This pull request fixes #332

I remembered to:

* [x] Update or add unit tests if needed (this should *fix* broken unit tests)
* [x] Update or add documentation/comments if needed (nothing needed)
* [x] Made sure stray files or whitespace didn't get committed (yes, yes)
* [x] If significant changes, branch from `develop` and set to merge into `develop` (nope)
* [x] Read the guidelines for contributing (yes, i did)

This was cherry-picked from #393 to at least get tests back online.