### PR TITLE
Update links after move to ArchiveTeam organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ As described in Nose documentation, run `nosetests3` in the top
 level of the project directory.
 
 Additionally, the project is [configured to use the free Travis CI]
-(https://travis-ci.org/chfoo/wpull).
+(https://travis-ci.org/ArchiveTeam/wpull).
 
 
 ### Making the PR

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ Wpull
 Wpull is a Wget-compatible (or remake/clone/replacement/alternative) web
 downloader and crawler.
 
-.. image:: https://raw.githubusercontent.com/chfoo/wpull/master/icon/wpull_logo_full.png
-   :target: https://github.com/chfoo/wpull
+.. image:: https://raw.githubusercontent.com/ArchiveTeam/wpull/master/icon/wpull_logo_full.png
+   :target: https://github.com/ArchiveTeam/wpull
    :alt: A dog pulling a box via a harness.
 
 Notable Features:
@@ -73,18 +73,18 @@ Need help? Please see our `Help
 <https://wpull.readthedocs.io/en/master/help.html>`_ page which contains
 frequently asked questions and support information.
 
-The issue tracker is located at https://github.com/chfoo/wpull/issues.
+The issue tracker is located at https://github.com/ArchiveTeam/wpull/issues.
 
 
 Dev
 ===
 
-.. image:: https://travis-ci.org/chfoo/wpull.png
-   :target: https://travis-ci.org/chfoo/wpull
+.. image:: https://travis-ci.org/ArchiveTeam/wpull.png
+   :target: https://travis-ci.org/ArchiveTeam/wpull
    :alt: Travis CI build status
 
-.. image:: https://coveralls.io/repos/chfoo/wpull/badge.png
-   :target: https://coveralls.io/r/chfoo/wpull
+.. image:: https://coveralls.io/repos/ArchiveTeam/wpull/badge.png
+   :target: https://coveralls.io/r/ArchiveTeam/wpull
    :alt: Coveralls report
 
 

--- a/doc/help.rst
+++ b/doc/help.rst
@@ -55,7 +55,7 @@ Wpull is giving an error or not performing correctly.
 Check that you have the options correct. In most cases, it is a misunderstanding of `Wget options <https://www.gnu.org/software/wget/manual/wget.html>`_.
 
 Otherwise if Wpull is not doing what you want, please visit the `issue tracker
-<https://github.com/chfoo/wpull/issues>`_ and see if your issue is there.
+<https://github.com/ArchiveTeam/wpull/issues>`_ and see if your issue is there.
 If not, please inform the developers by creating a new issue.
 
 When you open a new issue, GitHub provides a link to the guidelines
@@ -65,7 +65,7 @@ document. Please read it to learn how to file a good bug report.
 How can I help the development of Wpull? What are the development goals?
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Please visit the [GitHub repository](https://github.com/chfoo/wpull).
+Please visit the [GitHub repository](https://github.com/ArchiveTeam/wpull).
 From there, you can take a look at:
 
 * The Contributing file for specific instructions on how to help

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,7 +6,7 @@
 Welcome to Wpull's documentation!
 =================================
 
-:Homepage: https://github.com/chfoo/wpull
+:Homepage: https://github.com/ArchiveTeam/wpull
 
 Contents:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -60,13 +60,13 @@ Manual Install
 
 Install the dependencies known to work with Wpull::
 
-    pip3 install -r https://raw2.github.com/chfoo/wpull/master/requirements.txt
+    pip3 install -r https://raw.githubusercontent.com/ArchiveTeam/wpull/master/requirements.txt
 
 Install Wpull from GitHub::
 
-    pip3 install git+https://github.com/chfoo/wpull.git#egg=wpull
+    pip3 install git+https://github.com/ArchiveTeam/wpull.git#egg=wpull
 
-.. Tip:: Using ``git+https://github.com/chfoo/wpull.git@develop#egg=wpull``
+.. Tip:: Using ``git+https://github.com/ArchiveTeam/wpull.git@develop#egg=wpull``
    as the path will install Wpull's develop branch.
 
 

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -7,8 +7,8 @@ Introduction
 Wpull is a Wget-compatible (or remake/clone/replacement/alternative) web
 downloader and crawler.
 
-.. image:: https://raw.githubusercontent.com/chfoo/wpull/master/icon/wpull_logo_full.png
-   :target: https://github.com/chfoo/wpull
+.. image:: https://raw.githubusercontent.com/ArchiveTeam/wpull/master/icon/wpull_logo_full.png
+   :target: https://github.com/ArchiveTeam/wpull
    :alt: A dog pulling a box via a harness.
 
 Notable Features:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup_kwargs = dict(
     description='Wget-compatible web downloader and crawler.',
     author='Christopher Foo',
     author_email='chris.foo@gmail.com',
-    url='https://github.com/chfoo/wpull',
+    url='https://github.com/ArchiveTeam/wpull',
     package_data={'': [
         'cert/ca-bundle.pem',
         'testing/integration/sample_user_scripts/*.py',

--- a/wpull/document/htmlparse/lxml_.py
+++ b/wpull/document/htmlparse/lxml_.py
@@ -162,7 +162,7 @@ class HTMLParser(BaseParser):
 
         if parser_type == 'html':
             # XXX: Force libxml2 to do full read in case of early "</html>"
-            # See https://github.com/chfoo/wpull/issues/104
+            # See https://github.com/ArchiveTeam/wpull/issues/104
             # See https://bugzilla.gnome.org/show_bug.cgi?id=727935
             for dummy in range(3):
                 parser.feed('<html>'.encode(encoding))

--- a/wpull/protocol/http/client_test.py
+++ b/wpull/protocol/http/client_test.py
@@ -92,7 +92,7 @@ class TestClient(BadAppTestCase):
                 print(warn_obj)
 
             # Unrelated warnings may occur in PyPy
-            # https://travis-ci.org/chfoo/wpull/jobs/51420202
+            # https://travis-ci.org/ArchiveTeam/wpull/jobs/51420202
             self.assertGreaterEqual(len(warn_list), 1)
 
             for warn_obj in warn_list:


### PR DESCRIPTION
After moving the repo, a lot of links still point at chfoo’s repository.

(Also includes #363)