### PR TITLE
Remove get_exception_message

### DIFF
--- a/wpull/network/dns.py
+++ b/wpull/network/dns.py
@@ -254,16 +254,14 @@ class Resolver(HookableMixin):
         try:
             answer = yield from event_loop.run_in_executor(None, query)
         except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer) as error:
-            # dnspython doesn't raise an instance with a message, so use the
-            # class name instead.
             raise DNSNotFound(
                 'DNS resolution failed: {error}'
-                .format(error=wpull.util.get_exception_message(error))
+                .format(error=str(error))
             ) from error
         except dns.exception.DNSException as error:
             raise NetworkError(
                 'DNS resolution error: {error}'
-                .format(error=wpull.util.get_exception_message(error))
+                .format(error=str(error))
             ) from error
         else:
             return answer

--- a/wpull/util.py
+++ b/wpull/util.py
@@ -202,19 +202,6 @@ def close_on_error(close_func):
         raise
 
 
-def get_exception_message(instance):
-    '''Try to get the exception message or the class name.'''
-    args = getattr(instance, 'args', None)
-
-    if args:
-        return str(instance)
-
-    try:
-        return type(instance).__name__
-    except AttributeError:
-        return str(instance)
-
-
 class PickleStream(object):
     '''Pickle stream helper.'''
     def __init__(self, filename=None, file=None, mode='rb',

--- a/wpull/util_test.py
+++ b/wpull/util_test.py
@@ -7,7 +7,7 @@ from dns.resolver import NoNameservers
 
 from wpull.util import (datetime_str, python_version, filter_pem,
                         parse_iso8601_str, is_ascii, close_on_error,
-                        get_exception_message, GzipPickleStream)
+                        GzipPickleStream)
 
 
 DEFAULT_TIMEOUT = 30
@@ -70,44 +70,6 @@ class TestUtil(unittest.TestCase):
         my_object = MyObject()
         self.assertRaises(ValueError, my_object.oops)
         self.assertTrue(my_object.closed)
-
-    def test_get_exception_message(self):
-        self.assertEqual('oops', get_exception_message(ValueError('oops')))
-
-        try:
-            raise ValueError('oops')
-        except ValueError as error:
-            self.assertEqual('oops', get_exception_message(error))
-
-        self.assertEqual('ValueError', get_exception_message(ValueError()))
-
-        try:
-            raise ValueError
-        except ValueError as error:
-            self.assertEqual('ValueError', get_exception_message(error))
-
-        try:
-            raise ValueError()
-        except ValueError as error:
-            self.assertEqual('ValueError', get_exception_message(error))
-
-        self.assertEqual(
-            'NoNameservers', get_exception_message(NoNameservers())
-        )
-
-        try:
-            raise NoNameservers
-        except NoNameservers as error:
-            self.assertEqual(
-                'NoNameservers', get_exception_message(error)
-            )
-
-        try:
-            raise NoNameservers()
-        except NoNameservers as error:
-            self.assertEqual(
-                'NoNameservers', get_exception_message(error)
-            )
 
     def test_pickle_stream_filename(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
dnspython>=1.16 *has* error messages, rendering this workaround unnecessary. The function is not used anywhere else. This fixes issue #415.
