### PR TITLE
Upgrade html5lib to 1.0.1

### DIFF
--- a/wpull/document/html_test.py
+++ b/wpull/document/html_test.py
@@ -129,10 +129,7 @@ class Mixin(object):
             elements = tuple(reader.iter_elements(data, encoding=name))
 
             html_element = elements[0]
-            if isinstance(html_parser, LxmlHTMLParser):
-                self.assertEqual('html', html_element.tag)
-            else:
-                self.assertEqual('img', html_element.tag)
+            self.assertEqual('html', html_element.tag)
 
     def test_html_layout(self):
         html_parser = self.get_html_parser()
@@ -160,13 +157,9 @@ class Mixin(object):
         self.assertEqual('body', elements[5].tag)
         self.assertEqual('img', elements[6].tag)
 
-        if isinstance(html_parser, LxmlHTMLParser):
-            self.assertEqual('img', elements[7].tag)
-            self.assertEqual('body', elements[8].tag)
-            self.assertEqual('html', elements[9].tag)
-        else:
-            self.assertEqual('body', elements[7].tag)
-            self.assertEqual('html', elements[8].tag)
+        self.assertEqual('img', elements[7].tag)
+        self.assertEqual('body', elements[8].tag)
+        self.assertEqual('html', elements[9].tag)
 
     def test_html_early_html(self):
         reader = HTMLReader(self.get_html_parser())


### PR DESCRIPTION
The tokenizer module was never part of html5lib’s public interface and has consequently been made private in recent versions. This breaks wpull’s HTML scraper. This pull request contains a minimally invasive change, adding support for html5lib=1.0.1. A proper solution would extend TreeWalker to yield wpull’s tag stream directly.

Abusing html5lib to parse XML/RSS is not possible any more and yields incorrect tag streams (tag text is considered the tail of the closing tag). Thus, this change breaks test_rss_as_html and possibly other tests.

Please do not merge this proof of concept until the issues mentioned above are resolved.
