### PR TITLE
Update Travis-CI badge to use this repo's URI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,8 +79,8 @@ The issue tracker is located at https://github.com/chfoo/wpull/issues.
 Dev
 ===
 
-.. image:: https://travis-ci.org/chfoo/wpull.png
-   :target: https://travis-ci.org/chfoo/wpull
+.. image:: https://travis-ci.org/ArchiveTeam/wpull.png
+   :target: https://travis-ci.org/ArchiveTeam/wpull
    :alt: Travis CI build status
 
 .. image:: https://coveralls.io/repos/chfoo/wpull/badge.png


### PR DESCRIPTION
Please fill this or delete as needed:

This pull request fixes #438  (where N is the issue number).

I remembered to:

* [X] Update or add unit tests if needed
* [X] Update or add documentation/comments if needed
* [X] Made sure stray files or whitespace didn't get committed
* [X] If significant changes, branch from `develop` and set to merge into `develop`
* [X] Read the guidelines for contributing

Changes:

* Updates the URI in the README for Travis-CI checks to use this repo and not the URI of another repo.
