### PR TITLE
Fix spaces in URL query string

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Absolutely known to work versions only:
 chardet>=2.0.1,<=2.3
 dnspython3==1.12
-html5lib>=0.999,<1.0
+html5lib>=0.999,<=0.9999999
 lxml>=3.1.0,<=3.5
 namedlist>=1.3,<=1.7
 psutil>=2.0,<=4.2

--- a/wpull/url.py
+++ b/wpull/url.py
@@ -42,7 +42,7 @@ PASSWORD_ENCODE_SET = DEFAULT_ENCODE_SET | frozenset(b'/@\\')
 USERNAME_ENCODE_SET = PASSWORD_ENCODE_SET | frozenset(b':')
 '''Encoding set for usernames.'''
 
-QUERY_ENCODE_SET = frozenset(b'"#<>`')
+QUERY_ENCODE_SET = frozenset(b' "#<>`')
 '''Encoding set for query strings.
 
 This set does not include U+0020 (space) so it can be replaced with

--- a/wpull/url_test.py
+++ b/wpull/url_test.py
@@ -5,7 +5,8 @@ import unittest
 
 from wpull.url import URLInfo, schemes_similar, is_subdir, split_query, \
     percent_decode, percent_decode_plus, percent_encode, percent_encode_plus, \
-    uppercase_percent_encoding, urljoin, flatten_path, parse_url_or_log
+    uppercase_percent_encoding, urljoin, flatten_path, parse_url_or_log, \
+    normalize_query
 
 
 class TestURL(unittest.TestCase):
@@ -562,8 +563,10 @@ class TestURL(unittest.TestCase):
         self.assertEqual('að', percent_decode_plus('a%C3%B0'))
         self.assertEqual('a%20', percent_encode('a '))
         self.assertEqual('a%C3%B0', percent_encode('að'))
-        self.assertEqual('a+', percent_encode_plus('a '))
+        self.assertEqual('a%20', percent_encode_plus('a '))
         self.assertEqual('a%C3%B0', percent_encode_plus('að'))
+
+        self.assertEqual('a%20', normalize_query('a '))
 
     def test_uppercase_percent_encoding(self):
         self.assertEqual(


### PR DESCRIPTION
Please fill this or delete as needed:

This pull request fixes #445 

I remembered to:

* [x] Update or add unit tests if needed
* [x] Update or add documentation/comments if needed
* [x] Made sure stray files or whitespace didn't get committed
* [x] If significant changes, branch from `develop` and set to merge into `develop`
* [x] Read the guidelines for contributing

Changes:
