### PR TITLE
Fix missing --reject argument type

### DIFF
--- a/wpull/application/options.py
+++ b/wpull/application/options.py
@@ -1168,6 +1168,7 @@ class AppArgumentParser(argparse.ArgumentParser):
             '-R',
             '--reject',
             metavar='LIST',
+            type=self.comma_list,
             help=_('don’t download files with suffix in LIST'),
         )
         group.add_argument(

--- a/wpull/application/options_test.py
+++ b/wpull/application/options_test.py
@@ -39,3 +39,32 @@ class TestOptions(unittest.TestCase):
                 self.assertEqual(2, error.args[0])
             else:
                 self.assertTrue(False)
+
+    def test_comma_list_args(self):
+        arg_item_list = [
+            '--accept', '--reject',
+            '--domains', '--exclude-domains',
+            '--hostnames', '--exclude-hostnames',
+            '--follow-tags', '--ignore-tags',
+            '--include-directories', '--exclude-directories',
+            '--proxy-domains', '--proxy-exclude-domains',
+            '--proxy-hostnames', '--proxy-exclude-hostnames',
+            ]
+        arg_dest_list = [
+            'accept', 'reject',
+            'domains', 'exclude_domains',
+            'hostnames', 'exclude_hostnames',
+            'follow_tags', 'ignore_tags',
+            'include_directories', 'exclude_directories',
+            'proxy_domains', 'proxy_exclude_domains',
+            'proxy_hostnames', 'proxy_exclude_hostnames',
+            ]
+
+        cli_input = 'item1,item2,item3'
+        expected_value = ['item1', 'item2', 'item3']
+
+        for arg_item, arg_dest in zip(arg_item_list, arg_dest_list):
+            arg_parser = AppArgumentParser()
+
+            args = arg_parser.parse_args(['http://example.invalid'] + [arg_item, cli_input])
+            self.assertEqual(expected_value, vars(args)[arg_dest])


### PR DESCRIPTION
This pull request fixes a bug causing comma-separated options in the `--reject` option not being properly separated.

I remembered to:

* [x] Update or add unit tests if needed
* [x] Update or add documentation/comments if needed
* [x] Made sure stray files or whitespace didn't get committed
* [x] If significant changes, branch from `develop` and set to merge into `develop`
* [x] Read the guidelines for contributing

Changes:
* Specified type for the `--reject` command-line argument in the same style it is done for `--accept`.
