### PR TITLE
Change references from EFNet to hackint in docs

### DIFF
--- a/doc/help.rst
+++ b/doc/help.rst
@@ -78,8 +78,8 @@ How can I chat or ask a question?
 +++++++++++++++++++++++++++++++++
 
 For chatting and quick questions, please visit the "unoffical" IRC
-channel: `#archiveteam-bs <irc://irc.efnet.org/archiveteam-bs>`_ on
-EFNet. (`Click here <http://chat.efnet.org:9090/?channels=%23archiveteam-bs>`_
+channel: `#archiveteam-bs <irc://irc.hackint.org/archiveteam-bs>`_ on
+hackint. (`Click here <https://webirc.hackint.org/#irc://irc.hackint.org/archiveteam-bs>`_
 if you do not have an IRC client.)
 
 Alternatively if the discussion is lengthy, please use the issue


### PR DESCRIPTION
ArchiveTeam channels on EFnet are abandoned; hackint is the replacement.

not sure if the `irc://` link will work since my setup doesn't support those links atm.

I remembered to:

* [ ] Update or add unit tests if needed [N/A]
* [X] Update or add documentation/comments if needed
* [X] Made sure stray files or whitespace didn't get committed
* [X] If significant changes, branch from `develop` and set to merge into `develop` (these aren't significant so if you want me to switch to the master branch let me know)
* [X] Read the guidelines for contributing