### PR TITLE
Fix broken URLInfo.query_map attribute

### DIFF
--- a/wpull/url.py
+++ b/wpull/url.py
@@ -650,6 +650,10 @@ def split_query(qs, keep_blank_values=False):
     No processing is done on the actual values.
     '''
     items = []
+
+    if not qs:
+        return items
+
     for pair in qs.split('&'):
         name, delim, value = pair.partition('=')
 
@@ -678,7 +682,7 @@ def query_to_map(text):
         else:
             dict_obj[key].append('')
 
-    return query_to_map(text)
+    return dict_obj
 
 
 @functools.lru_cache()

--- a/wpull/url_test.py
+++ b/wpull/url_test.py
@@ -86,6 +86,7 @@ class TestURL(unittest.TestCase):
         self.assertEqual(81, url_info.port)
         self.assertEqual('/%C3%A1sdF%E2%80%8C/ghjK', url_info.path)
         self.assertEqual('a=b=c&D', url_info.query)
+        self.assertEqual({'a': ['b=c'], 'D': ['']}, url_info.query_map)
         self.assertEqual('/?', url_info.fragment)
         self.assertEqual('utf-8', url_info.encoding)
         self.assertEqual(
@@ -108,6 +109,7 @@ class TestURL(unittest.TestCase):
         self.assertEqual(21, url_info.port)
         self.assertEqual('/mydocs/', url_info.path)
         self.assertFalse(url_info.query)
+        self.assertEqual(url_info.query_map, {})
         self.assertFalse(url_info.fragment)
         self.assertEqual('utf-8', url_info.encoding)
         self.assertEqual(
@@ -388,6 +390,20 @@ class TestURL(unittest.TestCase):
         self.assertEqual(
             'http://example.com/?a=1&b=',
             URLInfo.parse('http://example.com?a=1&b=').url
+        )
+
+    def test_url_info_query_map(self):
+        self.assertEqual(
+            {'a': ['1'], 'b': ['2']},
+            URLInfo.parse('http://example.com?a=1&b=2').query_map
+        )
+        self.assertEqual(
+            {'a': ['1'], 'b': ['']},
+            URLInfo.parse('http://example.com?a=1&b').query_map
+        )
+        self.assertEqual(
+            {'a': ['1', '2']},
+            URLInfo.parse('http://example.com?a=1&a=2').query_map
         )
 
     def test_url_info_ipv6(self):


### PR DESCRIPTION
Accessing the URLInfo.query_map attribute generates a RecursionError due to a bug in the URLInfo.query_to_map method. This commit fixes that and adds tests to validate the documented behavior.

I remembered to:

* [x] Update or add unit tests if needed
* [x] Made sure stray files or whitespace didn't get committed
* [x] Read the guidelines for contributing

Changes:

* Fix bug in URLInfo.query_to_map
* Add unit tests for URLInfo.query_map