### PR TITLE
update inline condition for `link` element

### DIFF
--- a/wpull/scraper/html.py
+++ b/wpull/scraper/html.py
@@ -399,7 +399,7 @@ class ElementWalker(object):
         rel = element.attrib.get('rel', '')
         stylesheet = 'stylesheet' in rel
         icon = 'icon' in rel
-        inline = stylesheet or icon
+        inline = any((stylesheet, icon, 'manifest' in rel, 'preload' in rel, 'prefetch' in rel))
 
         if stylesheet:
             link_type = LinkType.css


### PR DESCRIPTION
Updated the condition for checking whether the link in a `link` element is inline or not, by checking whether the 'rel' attribute contains 'manifest', 'preload', or 'prefetch', to bring it more in line with the implementation in Wget2: https://gitlab.com/gnuwget/wget2/-/blob/761ae5082dae8a0b58727cd9e10dffd32cf8d03b/libwget/html_url.c#L223
