### PR TITLE
Add publicly viewable CI

### DIFF
--- a/.forgejo/workflows/test.yml
+++ b/.forgejo/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions: {}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ codeberg-small ]
+        container: [ python:3.4, python:3.5, python:3.6 ]
+    container: ${{ matrix.container }}
+    steps:
+      # GitHub Actions default was switched to nodejs20 and requires newer glibc. This causes images like ubuntu 18.04 to fail, but seems to also apply to python:3.4. (https://web.archive.org/web/20241224013414/https://github.com/actions/checkout/issues/1590)
+      # Fix is cloning directly w/o using the checkout action. ( https://web.archive.org/web/20250607154241/https://kishaningithub.github.io/blog/checking-out-code-using-github-action-in-legacy-runner/ )
+      - name: Clone repo w/o checkout action, which requires newer glibc than python:3.4 has
+        run: git clone --depth 1 -b "${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" .
+      - run: pip install -r requirements.txt
+      - run: pip install nose coverage warcat youtube-dl
+      - run: pip install . --no-dependencies
+      - run: nosetests --with-coverage --cover-package=wpull --cover-branches
+        continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,11 @@ permissions: {}
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ ubuntu-24.04, ubuntu-24.04-arm ]
         container: [ python:3.4, python:3.5, python:3.6 ]
     container: ${{ matrix.container }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions: {}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-24.04
+    container:
+      image: python:3.5
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install -r requirements.txt
+      - run: pip install nose coverage warcat youtube-dl
+      - run: pip install . --no-dependencies
+      - run: nosetests --with-coverage --cover-package=wpull --cover-branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,10 @@ jobs:
         container: [ python:3.4, python:3.5, python:3.6 ]
     container: ${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v4
+      # GitHub Actions default was switched to nodejs20 and requires newer glibc. This causes images like ubuntu 18.04 to fail, but seems to also apply to python:3.4. (https://web.archive.org/web/20241224013414/https://github.com/actions/checkout/issues/1590)
+      # Fix is cloning directly w/o using the checkout action. ( https://web.archive.org/web/20250607154241/https://kishaningithub.github.io/blog/checking-out-code-using-github-action-in-legacy-runner/ )
+      - name: Clone repo w/o checkout action, which requires newer glibc than python:3.4 has
+        run: git clone --depth 1 -b "${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" "https://github.com/${GITHUB_REPOSITORY}.git" .
       - run: pip install -r requirements.txt
       - run: pip install nose coverage warcat youtube-dl
       - run: pip install . --no-dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,4 @@ jobs:
       - run: pip install nose coverage warcat youtube-dl
       - run: pip install . --no-dependencies
       - run: nosetests --with-coverage --cover-package=wpull --cover-branches
+        continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       # GitHub Actions default was switched to nodejs20 and requires newer glibc. This causes images like ubuntu 18.04 to fail, but seems to also apply to python:3.4. (https://web.archive.org/web/20241224013414/https://github.com/actions/checkout/issues/1590)
       # Fix is cloning directly w/o using the checkout action. ( https://web.archive.org/web/20250607154241/https://kishaningithub.github.io/blog/checking-out-code-using-github-action-in-legacy-runner/ )
       - name: Clone repo w/o checkout action, which requires newer glibc than python:3.4 has
-        run: git clone --depth 1 -b "${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" "https://github.com/${GITHUB_REPOSITORY}.git" .
+        run: git clone --depth 1 -b "${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" .
       - run: pip install -r requirements.txt
       - run: pip install nose coverage warcat youtube-dl
       - run: pip install . --no-dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,11 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-24.04
-    container:
-      image: python:3.5
+    strategy:
+      fail-fast: false
+      matrix:
+        container: [ python:3.4, python:3.5, python:3.6 ]
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
       - run: pip install -r requirements.txt


### PR DESCRIPTION
This PR ports the existing Drone CI commands to GitHub Actions and Forgejo Actions.

It currently has both, but is created for the purpose of discussion. I do not necessarily believe that adding everything is a good idea.

## PR Details

The workflow is sufficiently generic that it could be ported easily to Forgejo by changing the base `runs-on`/"OS" of the job. For testing reasons, the Forgejo Actions specify Codeberg's runner.

I'd like to add Woodpecker CI, but testing it is not very easy, as Codeberg's implementation currently requires a manual application and review process.

GitHub Actions' recent addition of `arm64` also makes testing for that architecture much easier, though it is important to note that it is currently in "[Public Preview](https://github.com/orgs/community/discussions/148648)".

## CI-specific information/questions

At the time of writing, `python:3.5` and `python:3.6` fail with the following line:
```text
FAILED (SKIP=11, errors=10, failures=71)
```

`python:3.4` fails with the following line:
```text
FAILED (SKIP=11, errors=13, failures=71)
```

It is impossible for me to check whether this is expected or not, as there are no logs of previous or current CI runs.