### PR TITLE
Fix Sphinx version requirements

### DIFF
--- a/requirements-sphinx.txt
+++ b/requirements-sphinx.txt
@@ -11,5 +11,6 @@ typing>=3.5,<=3.5.1
 yapsy==1.11.223
 
 # for sphinx doc only:
+sphinx<1.7
 sphinx-argparse<=0.1.15
 sphinxcontrib-napoleon>=0.2.6,<=0.5.0


### PR DESCRIPTION
The existing requirements file causes Sphinx to error out when trying to build.

```console
$ make dirhtml
sphinx-build -b dirhtml -d _build/doctrees   . _build/dirhtml
Running Sphinx v3.5.4
/dir/wpull/.venv/lib/python3.5/site-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.9) or chardet (2.3.0) doesn't match a supported version!
  RequestsDependencyWarning)

Extension error:
Could not import extension sphinxarg.ext (exception: cannot import name 'Directive')
make: *** [dirhtml] Error 2
```

The Sphinx version was not specified properly, which causes it to update past a supported version, considering the other dependencies.

I'm testing this using a 3.5 venv, and installing requirements-sphinx, then running `make html` and `make dirhtml`.

There are 14 warnings, but now it does not fail outright.

This works towards fixing #495, but does not address the issue itself.